### PR TITLE
fix for Python 3.5.0/3.5.1 compatibility issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+1.1.1
+=====
+
+Bugfixes
+--------
+* Fixed import issue with Python 3.5.0 and 3.5.1
+  `#114 <https://github.com/awslabs/aws-encryption-sdk-cli/issues/114>`_
+
 1.1.0
 =====
 Public release

--- a/README.rst
+++ b/README.rst
@@ -18,11 +18,6 @@ Required Prerequisites
 * Python 2.7+ or 3.4+
 * aws-encryption-sdk >= 1.3.2
 
-.. warning::
-
-   Due to a `known issue with Python 3.5 prior to 3.5.2`_, imports will fail on Python 3.5.0
-   and 3.5.1. We are prioritizing fixing this problem.
-
 Installation
 ============
 
@@ -560,4 +555,3 @@ Execution
 .. _setuptools entry point: http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins
 .. _you must not specify a key: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/crypto-cli-how-to.html#crypto-cli-master-key
 .. _known issue with config file parsing in Windows: https://github.com/awslabs/aws-encryption-sdk-cli/issues/110
-.. _known issue with Python 3.5 prior to 3.5.2: https://github.com/awslabs/aws-encryption-sdk-cli/issues/114

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,9 @@ setup(
     author='Amazon Web Services',
     author_email='aws-cryptools@amazon.com',
     maintainer='Amazon Web Services',
-    description='This command line tool can be used to encrypt and decrypt files and directories using the AWS Encryption SDK.',
+    description=(
+        'This command line tool can be used to encrypt and decrypt files and directories using the AWS Encryption SDK.'
+    ),
     long_description=read('README.rst'),
     keywords='aws-encryption-sdk aws kms encryption cli command line',
     data_files=[

--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -17,7 +17,6 @@ import glob
 import logging
 import os
 import traceback
-from typing import List, Optional, Union  # noqa pylint: disable=unused-import
 
 import aws_encryption_sdk
 from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager  # noqa pylint: disable=unused-import
@@ -30,7 +29,14 @@ from aws_encryption_sdk_cli.internal.io_handling import IOHandler, output_filena
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME, setup_logger
 from aws_encryption_sdk_cli.internal.master_key_parsing import build_crypto_materials_manager_from_args
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter  # noqa pylint: disable=unused-import
-from aws_encryption_sdk_cli.internal.mypy_types import STREAM_KWARGS  # noqa pylint: disable=unused-import
+
+
+try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import List, Optional, Union  # noqa pylint: disable=unused-import
+    from aws_encryption_sdk_cli.internal.mypy_types import STREAM_KWARGS  # noqa pylint: disable=unused-import
+except ImportError:
+    # We only actually need these imports when running the mypy checks
+    pass
 
 __all__ = ('cli', 'process_cli_request', 'stream_kwargs_from_args')
 _LOGGER = logging.getLogger(LOGGER_NAME)

--- a/src/aws_encryption_sdk_cli/internal/arg_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/arg_parsing.py
@@ -18,7 +18,6 @@ import logging
 import os
 import platform
 import shlex
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union  # noqa pylint: disable=unused-import
 
 import aws_encryption_sdk
 
@@ -26,10 +25,16 @@ from aws_encryption_sdk_cli.exceptions import BadUserArgumentError, ParameterPar
 from aws_encryption_sdk_cli.internal.identifiers import __version__, ALGORITHM_NAMES, DEFAULT_MASTER_KEY_PROVIDER
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
-from aws_encryption_sdk_cli.internal.mypy_types import (  # noqa pylint: disable=unused-import
-    ARGPARSE_TEXT, CACHING_CONFIG, COLLAPSED_CONFIG,
-    MASTER_KEY_PROVIDER_CONFIG, PARSED_CONFIG, RAW_CONFIG
-)
+
+try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Any, Dict, List, Optional, Sequence, Tuple, Union  # noqa pylint: disable=unused-import
+    from aws_encryption_sdk_cli.internal.mypy_types import (  # noqa pylint: disable=unused-import
+        ARGPARSE_TEXT, CACHING_CONFIG, COLLAPSED_CONFIG,
+        MASTER_KEY_PROVIDER_CONFIG, PARSED_CONFIG, RAW_CONFIG
+    )
+except ImportError:
+    # We only actually need these imports when running the mypy checks
+    pass
 
 __all__ = ('parse_args',)
 _LOGGER = logging.getLogger(LOGGER_NAME)

--- a/src/aws_encryption_sdk_cli/internal/encoding.py
+++ b/src/aws_encryption_sdk_cli/internal/encoding.py
@@ -18,11 +18,16 @@ import io
 import logging
 import string
 from typing import IO, Iterable, List, Optional  # noqa pylint: disable=unused-import
-from types import TracebackType  # noqa pylint: disable=unused-import
 
 import six
 
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
+
+try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from types import TracebackType  # noqa pylint: disable=unused-import
+except ImportError:
+    # We only actually need these imports when running the mypy checks
+    pass
 
 __all__ = ('Base64IO',)
 _LOGGER = logging.getLogger(LOGGER_NAME)

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -12,7 +12,12 @@
 # language governing permissions and limitations under the License.
 """Static identifier values for the AWS Encryption SDK CLI."""
 from enum import Enum
-from typing import Dict, Set  # noqa pylint: disable=unused-import
+
+try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Dict, Set  # noqa pylint: disable=unused-import
+except ImportError:
+    # We only actually need these imports when running the mypy checks
+    pass
 
 import aws_encryption_sdk
 

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -30,7 +30,7 @@ __all__ = (
     'DEFAULT_MASTER_KEY_PROVIDER',
     'OperationResult'
 )
-__version__ = '1.1.0'  # type: str
+__version__ = '1.1.1'  # type: str
 
 #: Suffix added to output files if specific output filename is not specified.
 OUTPUT_SUFFIX = {

--- a/src/aws_encryption_sdk_cli/internal/io_handling.py
+++ b/src/aws_encryption_sdk_cli/internal/io_handling.py
@@ -17,7 +17,6 @@ import copy
 import logging
 import os
 import sys
-from typing import cast, Dict, IO, List, Type, Union  # noqa pylint: disable=unused-import
 
 import attr
 import aws_encryption_sdk
@@ -28,7 +27,13 @@ from aws_encryption_sdk_cli.internal.identifiers import OperationResult, OUTPUT_
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 from aws_encryption_sdk_cli.internal.metadata import json_ready_header, json_ready_header_auth
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
-from aws_encryption_sdk_cli.internal.mypy_types import SOURCE, STREAM_KWARGS  # noqa pylint: disable=unused-import
+
+try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import cast, Dict, IO, List, Type, Union  # noqa pylint: disable=unused-import
+    from aws_encryption_sdk_cli.internal.mypy_types import SOURCE, STREAM_KWARGS  # noqa pylint: disable=unused-import
+except ImportError:
+    # We only actually need these imports when running the mypy checks
+    pass
 
 __all__ = ('IOHandler', 'output_filename')
 _LOGGER = logging.getLogger(LOGGER_NAME)

--- a/src/aws_encryption_sdk_cli/internal/logging_utils.py
+++ b/src/aws_encryption_sdk_cli/internal/logging_utils.py
@@ -15,7 +15,12 @@ import codecs
 import copy
 import json
 import logging
-from typing import cast, Dict, Sequence, Text, Union  # noqa pylint: disable=unused-import
+
+try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import cast, Dict, Sequence, Text, Union  # noqa pylint: disable=unused-import
+except ImportError:
+    # We only actually need these imports when running the mypy checks
+    pass
 
 __all__ = ('setup_logger', 'LOGGER_NAME')
 LOGGING_LEVELS = {

--- a/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
@@ -14,7 +14,6 @@
 from collections import defaultdict
 import copy
 import logging
-from typing import Callable, DefaultDict, Dict, List, Union  # noqa pylint: disable=unused-import
 
 import aws_encryption_sdk
 from aws_encryption_sdk.key_providers.base import MasterKeyProvider  # noqa pylint: disable=unused-import
@@ -23,9 +22,15 @@ import pkg_resources
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal.identifiers import MASTER_KEY_PROVIDERS_ENTRY_POINT, PLUGIN_NAMESPACE_DIVIDER
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
-from aws_encryption_sdk_cli.internal.mypy_types import (  # noqa pylint: disable=unused-import
-    CACHING_CONFIG, RAW_MASTER_KEY_PROVIDER_CONFIG
-)
+
+try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Callable, DefaultDict, Dict, List, Union  # noqa pylint: disable=unused-import
+    from aws_encryption_sdk_cli.internal.mypy_types import (  # noqa pylint: disable=unused-import
+        CACHING_CONFIG, RAW_MASTER_KEY_PROVIDER_CONFIG
+    )
+except ImportError:
+    # We only actually need these imports when running the mypy checks
+    pass
 
 __all__ = ('build_crypto_materials_manager_from_args',)
 _LOGGER = logging.getLogger(LOGGER_NAME)

--- a/src/aws_encryption_sdk_cli/internal/metadata.py
+++ b/src/aws_encryption_sdk_cli/internal/metadata.py
@@ -17,13 +17,18 @@ from enum import Enum
 import json
 import os
 import sys
-from typing import Any, Dict, IO, Optional, Text  # noqa pylint: disable=unused-import
 from types import TracebackType  # noqa pylint: disable=unused-import
 
 import attr
 from aws_encryption_sdk.structures import MessageHeader  # noqa pylint: disable=unused-import
 from aws_encryption_sdk.internal.structures import MessageHeaderAuthentication  # noqa pylint: disable=unused-import
 import six
+
+try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Any, Dict, IO, Optional, Text  # noqa pylint: disable=unused-import
+except ImportError:
+    # We only actually need these imports when running the mypy checks
+    pass
 
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 

--- a/src/aws_encryption_sdk_cli/internal/mypy_types.py
+++ b/src/aws_encryption_sdk_cli/internal/mypy_types.py
@@ -11,36 +11,39 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Complex type constructions for use with mypy annotations."""
-import sys
-from typing import Dict, IO, List, Text, Union
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    import sys
+    from typing import Dict, IO, List, Text, Union
 
-from aws_encryption_sdk import Algorithm
-from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager
+    from aws_encryption_sdk import Algorithm
+    from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager
 
-__all__ = (
-    'STREAM_KWARGS',
-    'CACHING_CONFIG',
-    'RAW_MASTER_KEY_PROVIDER_CONFIG',
-    'MASTER_KEY_PROVIDER_CONFIG',
-    'RAW_CONFIG',
-    'PARSED_CONFIG',
-    'COLLAPSED_CONFIG',
-    'SOURCE',
-    'ARGPARSE_TEXT'
-)
+    __all__ = (
+        'STREAM_KWARGS',
+        'CACHING_CONFIG',
+        'RAW_MASTER_KEY_PROVIDER_CONFIG',
+        'MASTER_KEY_PROVIDER_CONFIG',
+        'RAW_CONFIG',
+        'PARSED_CONFIG',
+        'COLLAPSED_CONFIG',
+        'SOURCE',
+        'ARGPARSE_TEXT'
+    )
 
+    STREAM_KWARGS = Dict[str, Union[CryptoMaterialsManager, str, Dict[str, str], Algorithm, int]]
+    CACHING_CONFIG = Dict[str, Union[str, int, float]]
+    RAW_MASTER_KEY_PROVIDER_CONFIG = Dict[str, Union[str, List[str], Union[str, List[str]]]]
+    MASTER_KEY_PROVIDER_CONFIG = Dict[str, Union[str, List[str]]]
+    RAW_CONFIG = List[str]
+    PARSED_CONFIG = Dict[str, List[str]]
+    COLLAPSED_CONFIG = Dict[str, str]
+    SOURCE = Union[Text, str, bytes, IO]
 
-STREAM_KWARGS = Dict[str, Union[CryptoMaterialsManager, str, Dict[str, str], Algorithm, int]]
-CACHING_CONFIG = Dict[str, Union[str, int, float]]
-RAW_MASTER_KEY_PROVIDER_CONFIG = Dict[str, Union[str, List[str], Union[str, List[str]]]]
-MASTER_KEY_PROVIDER_CONFIG = Dict[str, Union[str, List[str]]]
-RAW_CONFIG = List[str]
-PARSED_CONFIG = Dict[str, List[str]]
-COLLAPSED_CONFIG = Dict[str, str]
-SOURCE = Union[Text, str, bytes, IO]
-
-# typeshed processing required to comply with argparse types
-if sys.version_info >= (3,):
-    ARGPARSE_TEXT = str  # pylint: disable=invalid-name
-else:
-    ARGPARSE_TEXT = Union[str, unicode]  # noqa: F821 # pylint: disable=undefined-variable
+    # typeshed processing required to comply with argparse types
+    if sys.version_info >= (3,):
+        ARGPARSE_TEXT = str  # pylint: disable=invalid-name
+    else:
+        ARGPARSE_TEXT = Union[str, unicode]  # noqa: F821 # pylint: disable=undefined-variable
+except ImportError:
+    # We only actually need these when running the mypy checks
+    pass

--- a/src/aws_encryption_sdk_cli/key_providers.py
+++ b/src/aws_encryption_sdk_cli/key_providers.py
@@ -12,13 +12,18 @@
 # language governing permissions and limitations under the License.
 """Master key providers."""
 import copy
-from typing import Dict, List, Text, Union  # noqa pylint: disable=unused-import
 
 from aws_encryption_sdk import KMSMasterKeyProvider
 import botocore.session
 
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
+
+try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Dict, List, Text, Union  # noqa pylint: disable=unused-import
+except ImportError:
+    # We only actually need these imports when running the mypy checks
+    pass
 
 __all__ = ('aws_kms_master_key_provider',)
 


### PR DESCRIPTION
fix for Python 3.5.0/3.5.1 compatibility issue #114 

Tested with Python:
* 2.7.13
* 3.4.6
* 3.5.0
* 3.5.1
* 3.5.2
* 3.5.3
* 3.6.2