### PR TITLE
Fix permissions issue on install, and update revision version number.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+1.1.2
+=====
+
+Bugfixes
+--------
+* Fixed permissions issue from installing metadata files
+  `#122 <https://github.com/awslabs/aws-encryption-sdk-cli/issues/122>`_
+
 1.1.1
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,6 @@ setup(
     ),
     long_description=read('README.rst'),
     keywords='aws-encryption-sdk aws kms encryption cli command line',
-    data_files=[
-        'README.rst',
-        'CHANGELOG.rst',
-        'LICENSE',
-        'requirements.txt'
-    ],
     license='Apache License 2.0',
     install_requires=get_requirements(),
     classifiers=[

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -30,7 +30,7 @@ __all__ = (
     'DEFAULT_MASTER_KEY_PROVIDER',
     'OperationResult'
 )
-__version__ = '1.1.1'  # type: str
+__version__ = '1.1.2'  # type: str
 
 #: Suffix added to output files if specific output filename is not specified.
 OUTPUT_SUFFIX = {


### PR DESCRIPTION
See also https://github.com/awslabs/aws-encryption-sdk-cli/issues/122

Testing:
- Reproduced permissions error using sdist install (`setup.py sdist` + `pip install aws-encryption-sdk-cli*.tar.gz`)
- Resolved permissions error with this patch applied using sdist install
- Double checked `MANIFEST.in` and verified output .tar.gz still includes metadata files (`README.rst`, `CHANGELOG.rst`, `LICENSE`, `requirements.txt`)
- Builds / unit tests pass

Assigning @mattsb42-aws as reviewer -- it's possible there's something I've missed here such that this isn't the right fix, but I think this might do it and I wanted to get a PR out ASAP to help prevent people from being blocked on install.