### PR TITLE
minor cleanup and blacklisting pytest 3.3.0

### DIFF
--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -31,7 +31,7 @@ from aws_encryption_sdk_cli.internal.master_key_parsing import build_crypto_mate
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter  # noqa pylint: disable=unused-import
 
 
-try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import List, Optional, Union  # noqa pylint: disable=unused-import
     from aws_encryption_sdk_cli.internal.mypy_types import STREAM_KWARGS  # noqa pylint: disable=unused-import
 except ImportError:

--- a/src/aws_encryption_sdk_cli/internal/arg_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/arg_parsing.py
@@ -26,7 +26,7 @@ from aws_encryption_sdk_cli.internal.identifiers import __version__, ALGORITHM_N
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
 
-try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Any, Dict, List, Optional, Sequence, Tuple, Union  # noqa pylint: disable=unused-import
     from aws_encryption_sdk_cli.internal.mypy_types import (  # noqa pylint: disable=unused-import
         ARGPARSE_TEXT, CACHING_CONFIG, COLLAPSED_CONFIG,

--- a/src/aws_encryption_sdk_cli/internal/encoding.py
+++ b/src/aws_encryption_sdk_cli/internal/encoding.py
@@ -17,14 +17,14 @@ import base64
 import io
 import logging
 import string
-from typing import IO, Iterable, List, Optional  # noqa pylint: disable=unused-import
+from types import TracebackType  # noqa pylint: disable=unused-import
 
 import six
 
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 
 try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
-    from types import TracebackType  # noqa pylint: disable=unused-import
+    from typing import IO, Iterable, List, Optional  # noqa pylint: disable=unused-import
 except ImportError:
     # We only actually need these imports when running the mypy checks
     pass

--- a/src/aws_encryption_sdk_cli/internal/encoding.py
+++ b/src/aws_encryption_sdk_cli/internal/encoding.py
@@ -23,7 +23,7 @@ import six
 
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 
-try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import IO, Iterable, List, Optional  # noqa pylint: disable=unused-import
 except ImportError:
     # We only actually need these imports when running the mypy checks

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -13,7 +13,7 @@
 """Static identifier values for the AWS Encryption SDK CLI."""
 from enum import Enum
 
-try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Dict, Set  # noqa pylint: disable=unused-import
 except ImportError:
     # We only actually need these imports when running the mypy checks

--- a/src/aws_encryption_sdk_cli/internal/io_handling.py
+++ b/src/aws_encryption_sdk_cli/internal/io_handling.py
@@ -28,7 +28,7 @@ from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 from aws_encryption_sdk_cli.internal.metadata import json_ready_header, json_ready_header_auth
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
 
-try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import cast, Dict, IO, List, Type, Union  # noqa pylint: disable=unused-import
     from aws_encryption_sdk_cli.internal.mypy_types import SOURCE, STREAM_KWARGS  # noqa pylint: disable=unused-import
 except ImportError:

--- a/src/aws_encryption_sdk_cli/internal/logging_utils.py
+++ b/src/aws_encryption_sdk_cli/internal/logging_utils.py
@@ -16,7 +16,7 @@ import copy
 import json
 import logging
 
-try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import cast, Dict, Sequence, Text, Union  # noqa pylint: disable=unused-import
 except ImportError:
     # We only actually need these imports when running the mypy checks

--- a/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
@@ -23,7 +23,7 @@ from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal.identifiers import MASTER_KEY_PROVIDERS_ENTRY_POINT, PLUGIN_NAMESPACE_DIVIDER
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 
-try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Callable, DefaultDict, Dict, List, Union  # noqa pylint: disable=unused-import
     from aws_encryption_sdk_cli.internal.mypy_types import (  # noqa pylint: disable=unused-import
         CACHING_CONFIG, RAW_MASTER_KEY_PROVIDER_CONFIG

--- a/src/aws_encryption_sdk_cli/internal/metadata.py
+++ b/src/aws_encryption_sdk_cli/internal/metadata.py
@@ -24,7 +24,7 @@ from aws_encryption_sdk.structures import MessageHeader  # noqa pylint: disable=
 from aws_encryption_sdk.internal.structures import MessageHeaderAuthentication  # noqa pylint: disable=unused-import
 import six
 
-try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Any, Dict, IO, Optional, Text  # noqa pylint: disable=unused-import
 except ImportError:
     # We only actually need these imports when running the mypy checks

--- a/src/aws_encryption_sdk_cli/key_providers.py
+++ b/src/aws_encryption_sdk_cli/key_providers.py
@@ -19,7 +19,7 @@ import botocore.session
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
 
-try: # Python 3.5.0 and 3.5.1 have incompatible typing modules
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Dict, List, Text, Union  # noqa pylint: disable=unused-import
 except ImportError:
     # We only actually need these imports when running the mypy checks

--- a/test/unit/test_encoding.py
+++ b/test/unit/test_encoding.py
@@ -266,6 +266,18 @@ def test_base64io_decode_with_whitespace(plaintext_source, b64_plaintext_with_wh
     assert test == plaintext_source[:read_bytes]
 
 
+@pytest.mark.parametrize('plaintext_source, b64_plaintext_with_whitespace, read_bytes', (
+    (b'\x00\x00\x00', b'AAAA', 3),
+))
+def test_base64io_decode_parametrized_null_bytes(plaintext_source, b64_plaintext_with_whitespace, read_bytes):
+    # Verifies that pytest is handling null bytes correctly (broken in 3.3.0)
+    # https://github.com/pytest-dev/pytest/issues/2957
+    with Base64IO(io.BytesIO(b64_plaintext_with_whitespace)) as decoder:
+        test = decoder.read(read_bytes)
+
+    assert test == plaintext_source[:read_bytes]
+
+
 def test_base64io_decode_read_only_from_buffer():
     plaintext_source = b'12345'
     plaintext_b64 = io.BytesIO(base64.b64encode(plaintext_source))

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ passenv =
 sitepackages = False
 deps =
     mock
-    pytest
+    pytest!=3.3.0
     pytest-catchlog
     pytest-cov
     pytest-mock


### PR DESCRIPTION
* Blacklisting pytest 3.3.0 (#125) and adding tests to make sure we catch it if pytest breaks in this way again. https://github.com/pytest-dev/pytest/issues/2957
* Fixing some minor formatting issues I missed in #118 