### PR TITLE
expanding input and output file paths to abspath and adding corresponding tests

### DIFF
--- a/src/aws_encryption_sdk_cli/internal/io_handling.py
+++ b/src/aws_encryption_sdk_cli/internal/io_handling.py
@@ -254,7 +254,7 @@ class IOHandler(object):
             if not self._should_write_file(destination):
                 return OperationResult.SKIPPED
             _ensure_dir_exists(destination)
-            destination_writer = open(destination, 'wb')
+            destination_writer = open(os.path.abspath(destination), 'wb')
 
         if source == '-':
             source = _stdin()
@@ -329,7 +329,7 @@ class IOHandler(object):
             _stream_args['source_length'] = source_file_size
 
         try:
-            with open(source, 'rb') as source_reader:
+            with open(os.path.abspath(source), 'rb') as source_reader:
                 operation_result = self.process_single_operation(
                     stream_args=_stream_args,
                     source=source_reader,

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -73,15 +73,19 @@ def test_encrypt_with_metadata_output_write_to_file(tmpdir):
 
 
 @pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
-def test_encrypt_with_metdata_full_file_path(tmpdir):
-    plaintext = tmpdir.join('source_plaintext')
-    plaintext.write_binary(os.urandom(1024))
-    ciphertext = tmpdir.join('ciphertext')
+def test_encrypt_with_metadata_full_file_path(tmpdir):
+    plaintext_filename = 'source_plaintext'
+    plaintext_file = tmpdir.join(plaintext_filename)
+    plaintext_file.write_binary(os.urandom(1024))
+    plaintext_file_full_path = str(plaintext_file)
+    ciphertext_filename = 'ciphertext'
+    ciphertext_file = tmpdir.join(ciphertext_filename)
+    ciphertext_file_full_path = str(ciphertext_file)
     metadata = tmpdir.join('metadata')
 
     encrypt_args = ENCRYPT_ARGS_TEMPLATE_WITH_METADATA.format(
-        source='source_plaintext',
-        target='ciphertext',
+        source=plaintext_filename,
+        target=ciphertext_filename,
         metadata='--metadata-output ' + str(metadata)
     )
 
@@ -90,8 +94,8 @@ def test_encrypt_with_metdata_full_file_path(tmpdir):
 
     raw_metadata = metadata.read()
     output_metadata = json.loads(raw_metadata)
-    assert output_metadata['input'] == str(plaintext)
-    assert output_metadata['output'] == str(ciphertext)
+    assert output_metadata['input'] == plaintext_file_full_path
+    assert output_metadata['output'] == ciphertext_file_full_path
 
 
 @pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -73,6 +73,28 @@ def test_encrypt_with_metadata_output_write_to_file(tmpdir):
 
 
 @pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+def test_encrypt_with_metdata_full_file_path(tmpdir):
+    plaintext = tmpdir.join('source_plaintext')
+    plaintext.write_binary(os.urandom(1024))
+    ciphertext = tmpdir.join('ciphertext')
+    metadata = tmpdir.join('metadata')
+
+    encrypt_args = ENCRYPT_ARGS_TEMPLATE_WITH_METADATA.format(
+        source='source_plaintext',
+        target='ciphertext',
+        metadata='--metadata-output ' + str(metadata)
+    )
+
+    with tmpdir.as_cwd():
+        aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
+
+    raw_metadata = metadata.read()
+    output_metadata = json.loads(raw_metadata)
+    assert output_metadata['input'] == str(plaintext)
+    assert output_metadata['output'] == str(ciphertext)
+
+
+@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
 def test_encrypt_with_metadata_output_write_to_stdout(tmpdir, capsys):
     plaintext = tmpdir.join('source_plaintext')
     plaintext.write_binary(os.urandom(1024))

--- a/test/unit/test_io_handling.py
+++ b/test/unit/test_io_handling.py
@@ -325,19 +325,22 @@ def test_process_single_operation_stdin_stdout(
 
 
 def test_process_single_operation_file(
+        tmpdir,
         patch_for_process_single_operation,
         patch_should_write_file,
         standard_handler
 ):
-    with patch('aws_encryption_sdk_cli.internal.io_handling.open', create=True) as mock_open:
-        standard_handler.process_single_operation(
-            stream_args=sentinel.stream_args,
-            source=sentinel.source,
-            destination=sentinel.destination_file
-        )
-    io_handling._ensure_dir_exists.assert_called_once_with(sentinel.destination_file)
-    patch_should_write_file.assert_called_once_with(sentinel.destination_file)
-    mock_open.assert_called_once_with(sentinel.destination_file, 'wb')
+    destination = tmpdir.join('destination')
+    with tmpdir.as_cwd():
+        with patch('aws_encryption_sdk_cli.internal.io_handling.open', create=True) as mock_open:
+            standard_handler.process_single_operation(
+                stream_args=sentinel.stream_args,
+                source=sentinel.source,
+                destination='destination'
+            )
+    io_handling._ensure_dir_exists.assert_called_once_with('destination')
+    patch_should_write_file.assert_called_once_with('destination')
+    mock_open.assert_called_once_with(str(destination), 'wb')
     io_handling.IOHandler._single_io_write.assert_called_once_with(
         stream_args=sentinel.stream_args,
         source=sentinel.source,


### PR DESCRIPTION
expanding input and output file paths to abspath and adding corresponding tests https://github.com/awslabs/aws-encryption-sdk-cli/issues/120