### PR TITLE
moving metadata writer to binary mode when writing to files

### DIFF
--- a/src/aws_encryption_sdk_cli/internal/metadata.py
+++ b/src/aws_encryption_sdk_cli/internal/metadata.py
@@ -83,7 +83,7 @@ class MetadataWriter(object):
         if not os.path.isdir(os.path.dirname(os.path.realpath(self.output_file))):
             raise BadUserArgumentError('Parent directory for requested metdata file does not exist.')
 
-        self._output_mode = 'a'
+        self._output_mode = 'ab'
         self.output_file = os.path.abspath(self.output_file)
 
         attr.validate(self)
@@ -93,7 +93,7 @@ class MetadataWriter(object):
     def force_overwrite(self):
         # type: () -> None
         """Force the output to overwrite the target metadata file."""
-        self._output_mode = 'w'
+        self._output_mode = 'wb'
 
     def open(self):
         # type: () -> None
@@ -121,7 +121,7 @@ class MetadataWriter(object):
         # Since we re-use each instance of this in a single call, we only want to overwrite
         # the first time if we are overwriting.
         if self.output_file != '-':
-            self._output_mode = 'a'
+            self._output_mode = 'ab'
 
     def __exit__(self, exc_type, exc_value, traceback):
         # type: (type, BaseException, TracebackType) -> None
@@ -137,8 +137,10 @@ class MetadataWriter(object):
         if self.suppress_output:
             return 0  # wrote 0 bytes
 
-        metadata_line = json.dumps(metadata, sort_keys=True)
-        return self._output_stream.write(metadata_line + os.linesep)
+        metadata_line = json.dumps(metadata, sort_keys=True) + os.linesep
+        if 'b' in self._output_mode:
+            metadata_line = metadata_line.encode('utf-8')
+        return self._output_stream.write(metadata_line)
 
 
 def unicode_b64_encode(value):

--- a/test/unit/test_metadata.py
+++ b/test/unit/test_metadata.py
@@ -23,8 +23,7 @@ from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal import metadata
 
 GOOD_INIT_KWARGS = dict(
-    suppress_output=False,
-    output_mode='w'
+    suppress_output=False
 )
 
 
@@ -38,7 +37,7 @@ def test_attrs_good(init_kwargs, call_kwargs):
 
 
 @pytest.mark.parametrize('init_kwargs_patch, error_type', (
-    (dict(suppress_output='not a bool'), TypeError),
+    (dict(suppress_output=None), TypeError),
 ))
 def test_attrs_fail(init_kwargs_patch, error_type):
     """Verifying that validators are applied because we overwrite attrs init."""
@@ -65,10 +64,10 @@ def test_custom_fail(init_kwargs, call_kwargs, error_type, error_message):
 
 
 @pytest.mark.parametrize('filename, force_overwrite, expected_mode', (
-    ('a_file', False, 'a'),
+    ('a_file', False, 'ab'),
     ('-', False, 'w'),
-    ('a_file', True, 'w'),
-    ('-', True, 'w')
+    ('a_file', True, 'wb'),
+    ('-', True, 'wb')
 ))
 def test_write_metadata_default_output_modes(filename, force_overwrite, expected_mode):
     test = metadata.MetadataWriter(suppress_output=False)(filename)
@@ -141,7 +140,7 @@ def test_append_metadata_file(tmpdir):
         'for': 'this metadata'
     }
     output_file = tmpdir.join('metadata')
-    output_file.write(initial_data + os.linesep)
+    output_file.write_binary((initial_data + os.linesep).encode('utf-8'))
 
     with metadata.MetadataWriter(suppress_output=False)(str(output_file)) as writer:
         writer.write_metadata(**my_metadata)
@@ -184,12 +183,12 @@ def test_overwrite_metdata_file_multiuse(tmpdir):
     long_lived_writer = metadata.MetadataWriter(suppress_output=False)(str(output_file))
     long_lived_writer.force_overwrite()
 
-    assert long_lived_writer._output_mode == 'w'
+    assert long_lived_writer._output_mode == 'wb'
 
     with long_lived_writer as writer:
         writer.write_metadata(**my_metadata)
 
-    assert long_lived_writer._output_mode == 'a'
+    assert long_lived_writer._output_mode == 'ab'
 
     with long_lived_writer as writer:
         writer.write_metadata(**my_metadata)


### PR DESCRIPTION
moving metadata writer to binary mode when writing to files https://github.com/awslabs/aws-encryption-sdk-cli/issues/121