### PR TITLE
moving integration tests off of config file and onto environment variables

### DIFF
--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -34,7 +34,7 @@ from aws_encryption_sdk_cli.internal.metadata import MetadataWriter  # noqa pyli
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import List, Optional, Union  # noqa pylint: disable=unused-import
     from aws_encryption_sdk_cli.internal.mypy_types import STREAM_KWARGS  # noqa pylint: disable=unused-import
-except ImportError:
+except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 

--- a/src/aws_encryption_sdk_cli/internal/arg_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/arg_parsing.py
@@ -32,7 +32,7 @@ try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
         ARGPARSE_TEXT, CACHING_CONFIG, COLLAPSED_CONFIG,
         MASTER_KEY_PROVIDER_CONFIG, PARSED_CONFIG, RAW_CONFIG
     )
-except ImportError:
+except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 

--- a/src/aws_encryption_sdk_cli/internal/encoding.py
+++ b/src/aws_encryption_sdk_cli/internal/encoding.py
@@ -25,7 +25,7 @@ from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import IO, Iterable, List, Optional  # noqa pylint: disable=unused-import
-except ImportError:
+except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -15,7 +15,7 @@ from enum import Enum
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Dict, Set  # noqa pylint: disable=unused-import
-except ImportError:
+except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 

--- a/src/aws_encryption_sdk_cli/internal/io_handling.py
+++ b/src/aws_encryption_sdk_cli/internal/io_handling.py
@@ -31,7 +31,7 @@ from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import cast, Dict, IO, List, Type, Union  # noqa pylint: disable=unused-import
     from aws_encryption_sdk_cli.internal.mypy_types import SOURCE, STREAM_KWARGS  # noqa pylint: disable=unused-import
-except ImportError:
+except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 

--- a/src/aws_encryption_sdk_cli/internal/logging_utils.py
+++ b/src/aws_encryption_sdk_cli/internal/logging_utils.py
@@ -18,7 +18,7 @@ import logging
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import cast, Dict, Sequence, Text, Union  # noqa pylint: disable=unused-import
-except ImportError:
+except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 

--- a/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
@@ -28,7 +28,7 @@ try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from aws_encryption_sdk_cli.internal.mypy_types import (  # noqa pylint: disable=unused-import
         CACHING_CONFIG, RAW_MASTER_KEY_PROVIDER_CONFIG
     )
-except ImportError:
+except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 

--- a/src/aws_encryption_sdk_cli/internal/metadata.py
+++ b/src/aws_encryption_sdk_cli/internal/metadata.py
@@ -26,7 +26,7 @@ import six
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Any, Dict, IO, Optional, Text, Union  # noqa pylint: disable=unused-import
-except ImportError:
+except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 

--- a/src/aws_encryption_sdk_cli/internal/mypy_types.py
+++ b/src/aws_encryption_sdk_cli/internal/mypy_types.py
@@ -44,6 +44,6 @@ try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
         ARGPARSE_TEXT = str  # pylint: disable=invalid-name
     else:
         ARGPARSE_TEXT = Union[str, unicode]  # noqa: F821 # pylint: disable=undefined-variable
-except ImportError:
+except ImportError:  # pragma: no cover
     # We only actually need these when running the mypy checks
     pass

--- a/src/aws_encryption_sdk_cli/key_providers.py
+++ b/src/aws_encryption_sdk_cli/key_providers.py
@@ -21,7 +21,7 @@ from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Dict, List, Text, Union  # noqa pylint: disable=unused-import
-except ImportError:
+except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 

--- a/test/integration/README.rst
+++ b/test/integration/README.rst
@@ -9,10 +9,6 @@ In order to run these integration tests successfully, these things which must be
 #. The ``AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_CONTROL`` environment variable must be set to ``RUN``.
 #. The ``AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID`` environment variable must be set to
    a valid `AWS KMS key id`_ that can be used by the available credentials.
-#. A CLI configuration file (as described in the readme) must be defined in this directory (test/integration)
-   with the filename ``integration_tests.conf``. This must contain at least the master key configuration
-   which will be used for the integration tests.
 
 .. _automatically discoverable credential locations: http://boto3.readthedocs.io/en/latest/guide/configuration.html
 .. _AWS KMS key id: http://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html
-.. _AWS configuration file: http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuration-file

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -10,8 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""Utility functions to handle configuration, credentials setup, and test skip
-decision making for integration tests."""
+"""Utility functions to handle configuration, credentials setup, and test skip decision making for integration tests."""
 from distutils.spawn import find_executable  # distutils confuses pylint: disable=import-error,no-name-in-module
 import logging
 import os
@@ -26,6 +25,7 @@ SKIP_MESSAGE = (
     'Required environment variables not found. Skipping integration tests.'
     ' See integration tests README.rst for more information.'
 )
+WINDOWS_SKIP_MESSAGE = 'Skipping test on Windows'
 TEST_CONTROL = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_CONTROL'
 AWS_KMS_KEY_ID = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID'
 
@@ -67,11 +67,12 @@ def encrypt_args_template(metadata=False, caching=False):
 
 
 def decrypt_args_template(metadata=False):
-    base = '-d -i {source} -o {target}'
+    template = '-d -i {source} -o {target}'
     if metadata:
-        return base + ' {metadata}'
+        template += ' {metadata}'
     else:
-        return base + ' -S'
+        template += ' -S'
+    return template
 
 
 @pytest.fixture

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -1,0 +1,86 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Utility functions to handle configuration, credentials setup, and test skip
+decision making for integration tests."""
+from distutils.spawn import find_executable  # distutils confuses pylint: disable=import-error,no-name-in-module
+import logging
+import os
+import platform
+
+import pytest
+import six
+
+from aws_encryption_sdk_cli.internal import logging_utils
+
+SKIP_MESSAGE = (
+    'Required environment variables not found. Skipping integration tests.'
+    ' See integration tests README.rst for more information.'
+)
+TEST_CONTROL = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_CONTROL'
+AWS_KMS_KEY_ID = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID'
+
+
+def is_windows():
+    return any(platform.win32_ver())
+
+
+def skip_tests():
+    """Only run tests if both required environment variables are found."""
+    test_control = os.environ.get(TEST_CONTROL, None)
+    key_id = os.environ.get(AWS_KMS_KEY_ID, None)
+    return not (test_control == 'RUN' and key_id is not None)
+
+
+def aws_encryption_cli_is_findable():
+    path = find_executable('aws-encryption-cli')
+    if path is None:
+        UserWarning('aws-encryption-cli executable could not be found')
+        return False
+    return True
+
+
+@pytest.fixture
+def cmk_arn():
+    """Retrieves the target CMK ARN from environment variable."""
+    return os.environ.get(AWS_KMS_KEY_ID)
+
+
+def encrypt_args_template(metadata=False, caching=False):
+    template = '-e -i {source} -o {target} --encryption-context a=b c=d -m key=' + cmk_arn()
+    if metadata:
+        template += ' {metadata}'
+    else:
+        template += ' -S'
+    if caching:
+        template += ' --caching capacity=10 max_age=60.0'
+    return template
+
+
+def decrypt_args_template(metadata=False):
+    base = '-d -i {source} -o {target}'
+    if metadata:
+        return base + ' {metadata}'
+    else:
+        return base + ' -S'
+
+
+@pytest.fixture
+def kms_redacting_logger_stream():
+    output_stream = six.StringIO()
+    formatter = logging_utils._KMSKeyRedactingFormatter(logging_utils.FORMAT_STRING)
+    handler = logging.StreamHandler(stream=output_stream)
+    handler.setFormatter(formatter)
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    return output_stream

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -15,7 +15,6 @@ import base64
 import filecmp
 import json
 import os
-import platform
 import shlex
 import shutil
 from subprocess import PIPE, Popen
@@ -25,7 +24,8 @@ import pytest
 import aws_encryption_sdk_cli
 from .integration_test_utils import (
     aws_encryption_cli_is_findable, decrypt_args_template,
-    encrypt_args_template, is_windows, SKIP_MESSAGE, skip_tests
+    encrypt_args_template, is_windows, SKIP_MESSAGE, skip_tests,
+    WINDOWS_SKIP_MESSAGE
 )
 
 
@@ -224,7 +224,7 @@ def test_file_to_file_cycle(tmpdir):
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.skipif(is_windows(), reason='Skipping symlink test on Windows')
+@pytest.mark.skipif(is_windows(), reason=WINDOWS_SKIP_MESSAGE)
 @pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_to_file_cycle_target_through_symlink(tmpdir):
     plaintext = tmpdir.join('source_plaintext')

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 """Integration testing suite for AWS Encryption SDK CLI."""
 import base64
-from distutils.spawn import find_executable  # distutils confuses pylint: disable=import-error,no-name-in-module
 import filecmp
 import json
 import os
@@ -24,43 +23,20 @@ from subprocess import PIPE, Popen
 import pytest
 
 import aws_encryption_sdk_cli
-
-ENABLE_TESTS_FLAG = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_CONTROL'
-HERE = os.path.abspath(os.path.dirname(__file__))
-CONFIG_FILE_NAME = os.path.join(HERE, 'integration_tests.conf')
-ENCRYPT_ARGS_TEMPLATE_BASE = '-e -i {source} -o {target} --encryption-context a=b c=d @' + CONFIG_FILE_NAME
-ENCRYPT_ARGS_TEMPLATE = ENCRYPT_ARGS_TEMPLATE_BASE + ' -S'
-ENCRYPT_ARGS_TEMPLATE_WITH_METADATA = ENCRYPT_ARGS_TEMPLATE_BASE + ' {metadata}'
-DECRYPT_ARGS_TEMPLATE_BASE = '-d -i {source} -o {target}'
-DECRYPT_ARGS_TEMPLATE = DECRYPT_ARGS_TEMPLATE_BASE + ' -S'
-DECRYPT_ARGS_TEMPLATE_WITH_METADATA = DECRYPT_ARGS_TEMPLATE_BASE + ' {metadata}'
-CACHING_CONFIG = ' --caching capacity=10 max_age=60.0'
+from .integration_test_utils import (
+    aws_encryption_cli_is_findable, decrypt_args_template,
+    encrypt_args_template, is_windows, SKIP_MESSAGE, skip_tests
+)
 
 
-def _should_run_tests():
-    return os.environ.get(ENABLE_TESTS_FLAG, None) == 'RUN'
-
-
-def _aws_encryption_cli_is_findable():
-    path = find_executable('aws-encryption-cli')
-    if path is None:
-        UserWarning('aws-encryption-cli executable could not be found')
-        return False
-    return True
-
-
-def _is_windows():
-    return any(platform.win32_ver())
-
-
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_encrypt_with_metadata_output_write_to_file(tmpdir):
     plaintext = tmpdir.join('source_plaintext')
     plaintext.write_binary(os.urandom(1024))
     ciphertext = tmpdir.join('ciphertext')
     metadata = tmpdir.join('metadata')
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE_WITH_METADATA.format(
+    encrypt_args = encrypt_args_template(metadata=True).format(
         source=str(plaintext),
         target=str(ciphertext),
         metadata='--metadata-output ' + str(metadata)
@@ -77,7 +53,7 @@ def test_encrypt_with_metadata_output_write_to_file(tmpdir):
     assert output_metadata['output'] == str(ciphertext)
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_encrypt_with_metadata_full_file_path(tmpdir):
     plaintext_filename = 'source_plaintext'
     plaintext_file = tmpdir.join(plaintext_filename)
@@ -88,7 +64,7 @@ def test_encrypt_with_metadata_full_file_path(tmpdir):
     ciphertext_file_full_path = str(ciphertext_file)
     metadata = tmpdir.join('metadata')
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE_WITH_METADATA.format(
+    encrypt_args = encrypt_args_template(metadata=True).format(
         source=plaintext_filename,
         target=ciphertext_filename,
         metadata='--metadata-output ' + str(metadata)
@@ -103,13 +79,13 @@ def test_encrypt_with_metadata_full_file_path(tmpdir):
     assert output_metadata['output'] == ciphertext_file_full_path
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_encrypt_with_metadata_output_write_to_stdout(tmpdir, capsys):
     plaintext = tmpdir.join('source_plaintext')
     plaintext.write_binary(os.urandom(1024))
     ciphertext = tmpdir.join('ciphertext')
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE_WITH_METADATA.format(
+    encrypt_args = encrypt_args_template(metadata=True).format(
         source=str(plaintext),
         target=str(ciphertext),
         metadata='--metadata-output -'
@@ -126,7 +102,7 @@ def test_encrypt_with_metadata_output_write_to_stdout(tmpdir, capsys):
     assert output_metadata['output'] == str(ciphertext)
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_cycle_with_metadata_output_append(tmpdir):
     plaintext = tmpdir.join('source_plaintext')
     plaintext.write_binary(os.urandom(1024))
@@ -134,12 +110,12 @@ def test_cycle_with_metadata_output_append(tmpdir):
     decrypted = tmpdir.join('decrypted')
     metadata = tmpdir.join('metadata')
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE_WITH_METADATA.format(
+    encrypt_args = encrypt_args_template(metadata=True).format(
         source=str(plaintext),
         target=str(ciphertext),
         metadata='--metadata-output ' + str(metadata)
     )
-    decrypt_args = DECRYPT_ARGS_TEMPLATE_WITH_METADATA.format(
+    decrypt_args = decrypt_args_template(metadata=True).format(
         source=str(ciphertext),
         target=str(decrypted),
         metadata='--metadata-output ' + str(metadata)
@@ -163,7 +139,7 @@ def test_cycle_with_metadata_output_append(tmpdir):
     assert 'header_auth' in output_metadata[1]
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 @pytest.mark.parametrize('required_encryption_context', (
     'a',
     'c',
@@ -181,11 +157,11 @@ def test_file_to_file_decrypt_required_encryption_context_success(tmpdir, requir
     with open(str(plaintext), 'wb') as f:
         f.write(os.urandom(1024))
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext),
         target=str(ciphertext)
     )
-    decrypt_args = DECRYPT_ARGS_TEMPLATE.format(
+    decrypt_args = decrypt_args_template().format(
         source=str(ciphertext),
         target=str(decrypted)
     ) + ' --encryption-context ' + required_encryption_context
@@ -196,7 +172,7 @@ def test_file_to_file_decrypt_required_encryption_context_success(tmpdir, requir
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 @pytest.mark.parametrize('required_encryption_context', ('a=VALUE_NOT_FOUND', 'KEY_NOT_FOUND'))
 def test_file_to_file_decrypt_required_encryption_context_fail(tmpdir, required_encryption_context):
     plaintext = tmpdir.join('source_plaintext')
@@ -205,11 +181,11 @@ def test_file_to_file_decrypt_required_encryption_context_fail(tmpdir, required_
     metadata_file = tmpdir.join('metadata')
     decrypted = tmpdir.join('decrypted')
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext),
         target=str(ciphertext)
     )
-    decrypt_args = DECRYPT_ARGS_TEMPLATE_WITH_METADATA.format(
+    decrypt_args = decrypt_args_template(metadata=True).format(
         source=str(ciphertext),
         target=str(decrypted),
         metadata=' --metadata-output ' + str(metadata_file)
@@ -225,7 +201,7 @@ def test_file_to_file_decrypt_required_encryption_context_fail(tmpdir, required_
     assert parsed_metadata['reason'] == 'Missing encryption context key or value'
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_to_file_cycle(tmpdir):
     plaintext = tmpdir.join('source_plaintext')
     ciphertext = tmpdir.join('ciphertext')
@@ -233,11 +209,11 @@ def test_file_to_file_cycle(tmpdir):
     with open(str(plaintext), 'wb') as f:
         f.write(os.urandom(1024))
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext),
         target=str(ciphertext)
     )
-    decrypt_args = DECRYPT_ARGS_TEMPLATE.format(
+    decrypt_args = decrypt_args_template().format(
         source=str(ciphertext),
         target=str(decrypted)
     )
@@ -248,8 +224,8 @@ def test_file_to_file_cycle(tmpdir):
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.skipif(_is_windows(), reason='Skipping symlink test on Windows')
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(is_windows(), reason='Skipping symlink test on Windows')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_to_file_cycle_target_through_symlink(tmpdir):
     plaintext = tmpdir.join('source_plaintext')
     output_dir = tmpdir.mkdir('output')
@@ -259,11 +235,11 @@ def test_file_to_file_cycle_target_through_symlink(tmpdir):
     with open(str(plaintext), 'wb') as f:
         f.write(os.urandom(1024))
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext),
         target=str(ciphertext)
     )
-    decrypt_args = DECRYPT_ARGS_TEMPLATE.format(
+    decrypt_args = decrypt_args_template().format(
         source=str(ciphertext),
         target=str(decrypted)
     )
@@ -274,7 +250,7 @@ def test_file_to_file_cycle_target_through_symlink(tmpdir):
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 @pytest.mark.parametrize('encode, decode', (
     (True, False),
     (False, True),
@@ -293,11 +269,11 @@ def test_file_to_file_base64(tmpdir, encode, decode):
     encrypt_flag = ' --encode' if encode else ''
     decrypt_flag = ' --decode' if decode else ''
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext),
         target=str(ciphertext_a)
     ) + encrypt_flag
-    decrypt_args = DECRYPT_ARGS_TEMPLATE.format(
+    decrypt_args = decrypt_args_template().format(
         source=str(ciphertext_b),
         target=str(decrypted)
     ) + decrypt_flag
@@ -322,7 +298,7 @@ def test_file_to_file_base64(tmpdir, encode, decode):
     assert decrypted_plaintext == plaintext_source
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_to_file_cycle_with_caching(tmpdir):
     plaintext = tmpdir.join('source_plaintext')
     ciphertext = tmpdir.join('ciphertext')
@@ -330,11 +306,11 @@ def test_file_to_file_cycle_with_caching(tmpdir):
     with open(str(plaintext), 'wb') as f:
         f.write(os.urandom(1024))
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template(caching=True).format(
         source=str(plaintext),
         target=str(ciphertext)
-    ) + CACHING_CONFIG
-    decrypt_args = DECRYPT_ARGS_TEMPLATE.format(
+    )
+    decrypt_args = decrypt_args_template().format(
         source=str(ciphertext),
         target=str(decrypted)
     )
@@ -345,14 +321,14 @@ def test_file_to_file_cycle_with_caching(tmpdir):
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_overwrite_source_file_to_file_custom_empty_prefix(tmpdir):
     plaintext_source = os.urandom(2014)
     plaintext = tmpdir.join('source_plaintext')
     with open(str(plaintext), 'wb') as f:
         f.write(plaintext_source)
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext),
         target=str(plaintext)
     ) + ' --suffix'
@@ -365,14 +341,14 @@ def test_file_overwrite_source_file_to_file_custom_empty_prefix(tmpdir):
         assert f.read() == plaintext_source
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_overwrite_source_dir_to_dir_custom_empty_prefix(tmpdir):
     plaintext_source = os.urandom(2014)
     plaintext = tmpdir.join('source_plaintext')
     with open(str(plaintext), 'wb') as f:
         f.write(plaintext_source)
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(tmpdir),
         target=str(tmpdir)
     ) + ' --suffix'
@@ -385,14 +361,14 @@ def test_file_overwrite_source_dir_to_dir_custom_empty_prefix(tmpdir):
         assert f.read() == plaintext_source
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_overwrite_source_file_to_dir_custom_empty_prefix(tmpdir):
     plaintext_source = os.urandom(2014)
     plaintext = tmpdir.join('source_plaintext')
     with open(str(plaintext), 'wb') as f:
         f.write(plaintext_source)
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext),
         target=str(tmpdir)
     ) + ' --suffix'
@@ -405,7 +381,7 @@ def test_file_overwrite_source_file_to_dir_custom_empty_prefix(tmpdir):
         assert f.read() == plaintext_source
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_to_dir_cycle(tmpdir):
     inner_dir = tmpdir.mkdir('inner')
     plaintext = tmpdir.join('source_plaintext')
@@ -414,11 +390,11 @@ def test_file_to_dir_cycle(tmpdir):
     with open(str(plaintext), 'wb') as f:
         f.write(os.urandom(1024))
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext),
         target=str(inner_dir)
     )
-    decrypt_args = DECRYPT_ARGS_TEMPLATE.format(
+    decrypt_args = decrypt_args_template().format(
         source=str(ciphertext),
         target=str(decrypted)
     )
@@ -430,17 +406,17 @@ def test_file_to_dir_cycle(tmpdir):
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.skipif(not _aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_stdin_to_file_to_stdout_cycle(tmpdir):
     ciphertext_file = tmpdir.join('ciphertext')
     plaintext = os.urandom(1024)
 
-    encrypt_args = 'aws-encryption-cli ' + ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = 'aws-encryption-cli ' + encrypt_args_template().format(
         source='-',
         target=str(ciphertext_file)
     )
-    decrypt_args = 'aws-encryption-cli ' + DECRYPT_ARGS_TEMPLATE.format(
+    decrypt_args = 'aws-encryption-cli ' + decrypt_args_template().format(
         source=str(ciphertext_file),
         target='-'
     )
@@ -454,16 +430,16 @@ def test_stdin_to_file_to_stdout_cycle(tmpdir):
     assert decrypted_stdout == plaintext
 
 
-@pytest.mark.skipif(not _aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_stdin_stdout_stdin_stdout_cycle():
     plaintext = os.urandom(1024)
 
-    encrypt_args = 'aws-encryption-cli ' + ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = 'aws-encryption-cli ' + encrypt_args_template().format(
         source='-',
         target='-'
     )
-    decrypt_args = 'aws-encryption-cli ' + DECRYPT_ARGS_TEMPLATE.format(
+    decrypt_args = 'aws-encryption-cli ' + decrypt_args_template().format(
         source='-',
         target='-'
     )
@@ -475,8 +451,8 @@ def test_stdin_stdout_stdin_stdout_cycle():
     assert decrypted_stdout == plaintext
 
 
-@pytest.mark.skipif(not _aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 @pytest.mark.parametrize('required_encryption_context', ('a=VALUE_NOT_FOUND', 'KEY_NOT_FOUND'))
 def test_file_to_stdout_decrypt_required_encryption_context_fail(tmpdir, required_encryption_context):
     plaintext = tmpdir.join('source_plaintext')
@@ -484,11 +460,11 @@ def test_file_to_stdout_decrypt_required_encryption_context_fail(tmpdir, require
     ciphertext = tmpdir.join('ciphertext')
     metadata_file = tmpdir.join('metadata')
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext),
         target=str(ciphertext)
     )
-    decrypt_args = 'aws-encryption-cli ' + DECRYPT_ARGS_TEMPLATE_WITH_METADATA.format(
+    decrypt_args = 'aws-encryption-cli ' + decrypt_args_template(metadata=True).format(
         source=str(ciphertext),
         target='-',
         metadata=' --metadata-output ' + str(metadata_file)
@@ -511,7 +487,7 @@ def test_file_to_stdout_decrypt_required_encryption_context_fail(tmpdir, require
     assert parsed_metadata['reason'] == 'Missing encryption context key or value'
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_dir_to_dir_cycle(tmpdir):
     plaintext_dir = tmpdir.mkdir('plaintext')
     ciphertext_dir = tmpdir.mkdir('ciphertext')
@@ -522,11 +498,11 @@ def test_dir_to_dir_cycle(tmpdir):
         with open(os.path.join(str(plaintext_dir), *source_file_path), 'wb') as file:
             file.write(os.urandom(1024))
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext_dir),
         target=str(ciphertext_dir)
     ) + ' -r'
-    decrypt_args = DECRYPT_ARGS_TEMPLATE.format(
+    decrypt_args = decrypt_args_template().format(
         source=str(ciphertext_dir),
         target=str(decrypted_dir)
     ) + ' -r'
@@ -544,7 +520,7 @@ def test_dir_to_dir_cycle(tmpdir):
             assert filecmp.cmp(plaintext_filename, decrypted_filename)
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_dir_to_dir_cycle_custom_suffix(tmpdir):
     plaintext_dir = tmpdir.mkdir('plaintext')
     ciphertext_dir = tmpdir.mkdir('ciphertext')
@@ -556,12 +532,12 @@ def test_dir_to_dir_cycle_custom_suffix(tmpdir):
             file.write(os.urandom(1024))
 
     encrypt_suffix = 'THIS_IS_A_CUSTOM_SUFFIX'
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext_dir),
         target=str(ciphertext_dir)
     ) + ' -r' + ' --suffix ' + encrypt_suffix
     decrypt_suffix = '.anotherSuffix'
-    decrypt_args = DECRYPT_ARGS_TEMPLATE.format(
+    decrypt_args = decrypt_args_template().format(
         source=str(ciphertext_dir),
         target=str(decrypted_dir)
     ) + ' -r' + ' --suffix ' + decrypt_suffix
@@ -579,7 +555,7 @@ def test_dir_to_dir_cycle_custom_suffix(tmpdir):
             assert filecmp.cmp(plaintext_filename, decrypted_filename)
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_glob_to_dir_cycle(tmpdir):
     plaintext_dir = tmpdir.mkdir('plaintext')
     ciphertext_dir = tmpdir.mkdir('ciphertext')
@@ -590,11 +566,11 @@ def test_glob_to_dir_cycle(tmpdir):
 
     suffix = '.1'
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=os.path.join(str(plaintext_dir), '*' + suffix),
         target=str(ciphertext_dir)
     ) + ' -r'
-    decrypt_args = DECRYPT_ARGS_TEMPLATE.format(
+    decrypt_args = decrypt_args_template().format(
         source=str(ciphertext_dir),
         target=str(decrypted_dir)
     ) + ' -r'

--- a/test/integration/test_i_key_providers.py
+++ b/test/integration/test_i_key_providers.py
@@ -18,17 +18,17 @@ import pytest
 
 import aws_encryption_sdk_cli
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
-from .test_i_aws_encryption_sdk_cli import _should_run_tests, ENCRYPT_ARGS_TEMPLATE
-from .test_i_logging_utils import kms_redacting_logger_stream  # noqa pylint: disable=unused-import
+from .integration_test_utils import kms_redacting_logger_stream  # noqa pylint: disable=unused-import
+from .integration_test_utils import encrypt_args_template, SKIP_MESSAGE, skip_tests
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_encrypt_verify_user_agent(tmpdir, kms_redacting_logger_stream):
     plaintext = tmpdir.join('source_plaintext')
     plaintext.write_binary(os.urandom(1024))
     ciphertext = tmpdir.join('ciphertext')
 
-    encrypt_args = ENCRYPT_ARGS_TEMPLATE.format(
+    encrypt_args = encrypt_args_template().format(
         source=str(plaintext),
         target=str(ciphertext)
     ) + ' -vvvv'

--- a/test/integration/test_i_key_providers.py
+++ b/test/integration/test_i_key_providers.py
@@ -18,8 +18,8 @@ import pytest
 
 import aws_encryption_sdk_cli
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
-from .integration_test_utils import kms_redacting_logger_stream  # noqa pylint: disable=unused-import
 from .integration_test_utils import encrypt_args_template, SKIP_MESSAGE, skip_tests
+from .integration_test_utils import kms_redacting_logger_stream  # noqa pylint: disable=unused-import
 
 
 @pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)

--- a/test/integration/test_i_logging_utils.py
+++ b/test/integration/test_i_logging_utils.py
@@ -13,80 +13,55 @@
 """Unit testing suite for ``aws_encryption_sdk_cli.internal.logging``."""
 import base64
 import codecs
-import logging
-import os
 
 import boto3
 import pytest
-import six
 
 from aws_encryption_sdk_cli.internal import logging_utils
-from .test_i_aws_encryption_sdk_cli import _should_run_tests as meta_should_run_tests
-
-AWS_KMS_KEY_ID = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID'
-
-
-def _should_run_tests():
-    return AWS_KMS_KEY_ID in os.environ and meta_should_run_tests()
+from .integration_test_utils import cmk_arn, kms_redacting_logger_stream  # noqa pylint: disable=unused-import
+from .integration_test_utils import SKIP_MESSAGE, skip_tests
 
 
 @pytest.fixture
-def kms_redacting_logger_stream():
-    output_stream = six.StringIO()
-    formatter = logging_utils._KMSKeyRedactingFormatter(logging_utils.FORMAT_STRING)
-    handler = logging.StreamHandler(stream=output_stream)
-    handler.setFormatter(formatter)
-    logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(handler)
-    return output_stream
-
-
-@pytest.fixture
-def kms_key():
-    return os.environ.get(AWS_KMS_KEY_ID)
-
-
-@pytest.fixture
-def kms_client(kms_key):
-    region = kms_key.split(':')[3]
+def kms_client(cmk_arn):
+    region = cmk_arn.split(':')[3]
     return boto3.client('kms', region_name=region)
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
-def test_kms_generate_data_key(kms_redacting_logger_stream, kms_client, kms_key):
-    response = kms_client.generate_data_key(KeyId=kms_key, NumberOfBytes=32)
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
+def test_kms_generate_data_key(kms_redacting_logger_stream, kms_client, cmk_arn):
+    response = kms_client.generate_data_key(KeyId=cmk_arn, NumberOfBytes=32)
 
     log_output = kms_redacting_logger_stream.getvalue()
 
     assert log_output.count(logging_utils._REDACTED) == 1
-    assert log_output.count(kms_key) == 2
+    assert log_output.count(cmk_arn) == 2
     assert codecs.decode(base64.b64encode(response['Plaintext']), 'utf-8') not in log_output
     assert log_output.count(codecs.decode(base64.b64encode(response['CiphertextBlob']), 'utf-8')) == 1
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
-def test_kms_encrypt(kms_redacting_logger_stream, kms_client, kms_key):
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
+def test_kms_encrypt(kms_redacting_logger_stream, kms_client, cmk_arn):
     raw_plaintext = b'some secret data'
-    response = kms_client.encrypt(KeyId=kms_key, Plaintext=raw_plaintext)
+    response = kms_client.encrypt(KeyId=cmk_arn, Plaintext=raw_plaintext)
 
     log_output = kms_redacting_logger_stream.getvalue()
 
     assert log_output.count(logging_utils._REDACTED) == 1
-    assert log_output.count(kms_key) == 2
+    assert log_output.count(cmk_arn) == 2
     assert codecs.decode(base64.b64encode(raw_plaintext), 'utf-8') not in log_output
     assert log_output.count(codecs.decode(base64.b64encode(response['CiphertextBlob']), 'utf-8')) == 1
 
 
-@pytest.mark.skipif(not _should_run_tests(), reason='Integration tests disabled. See test/integration/README.rst')
-def test_kms_decrypt(kms_redacting_logger_stream, kms_client, kms_key):
+@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
+def test_kms_decrypt(kms_redacting_logger_stream, kms_client, cmk_arn):
     raw_plaintext = b'some secret data'
-    encrypt_response = kms_client.encrypt(KeyId=kms_key, Plaintext=raw_plaintext)
+    encrypt_response = kms_client.encrypt(KeyId=cmk_arn, Plaintext=raw_plaintext)
     kms_client.decrypt(CiphertextBlob=encrypt_response['CiphertextBlob'])
 
     log_output = kms_redacting_logger_stream.getvalue()
 
     assert log_output.count(logging_utils._REDACTED) == 2
-    assert log_output.count(kms_key) == 3
+    assert log_output.count(cmk_arn) == 3
     assert codecs.decode(base64.b64encode(raw_plaintext), 'utf-8') not in log_output
     assert log_output.count(codecs.decode(base64.b64encode(encrypt_response['CiphertextBlob']), 'utf-8')) == 2

--- a/test/unit/test_aws_encryption_sdk_cli.py
+++ b/test/unit/test_aws_encryption_sdk_cli.py
@@ -13,7 +13,6 @@
 """Unit test suite for ``aws_encryption_sdk_cli``."""
 import logging
 import os
-import platform
 import shlex
 
 import aws_encryption_sdk
@@ -25,10 +24,7 @@ import aws_encryption_sdk_cli
 from aws_encryption_sdk_cli.exceptions import AWSEncryptionSDKCLIError, BadUserArgumentError
 from aws_encryption_sdk_cli.internal.logging_utils import _KMSKeyRedactingFormatter, FORMAT_STRING
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
-
-
-def _is_windows():
-    return any(platform.win32_ver())
+from .unit_test_utils import is_windows
 
 
 @pytest.fixture
@@ -89,7 +85,7 @@ def build_same_files_and_dirs(tmpdir, source_is_symlink, dest_is_symlink, use_fi
 
 
 def build_same_file_and_dir_test_cases():
-    if _is_windows():
+    if is_windows():
         return [
             (False, False, True),
             (False, False, False)
@@ -188,7 +184,7 @@ def build_bad_metadata_file_requests():
         (False, False, 'source'),
         (False, False, 'dest')
     ]
-    if not _is_windows():
+    if not is_windows():
         bad_requests.extend([
             (True, False, 'source'),
             (False, True, 'source'),

--- a/test/unit/test_io_handling.py
+++ b/test/unit/test_io_handling.py
@@ -14,7 +14,6 @@
 import base64
 import io
 import os
-import platform
 import sys
 
 from mock import MagicMock, patch, sentinel
@@ -23,12 +22,9 @@ from pytest_mock import mocker  # noqa pylint: disable=unused-import
 import six
 
 from aws_encryption_sdk_cli.internal import identifiers, io_handling, metadata
+from .unit_test_utils import is_windows, WINDOWS_SKIP_MESSAGE
 
 DATA = b'aosidhjf9aiwhj3f98wiaj49c8a3hj49f8uwa0edifja9w843hj98'
-
-
-def _is_windows():
-    return any(platform.win32_ver())
 
 
 @pytest.yield_fixture
@@ -504,7 +500,7 @@ def test_process_single_file_source_is_destination(tmpdir, patch_process_single_
     assert not patch_process_single_operation.called
 
 
-@pytest.mark.skipif(_is_windows(), reason='Skipping symlink test on Windows')
+@pytest.mark.skipif(is_windows(), reason=WINDOWS_SKIP_MESSAGE)
 def test_process_single_file_destination_is_symlink_to_source(
         tmpdir,
         patch_process_single_operation,

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -1,0 +1,20 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Utility functions to handle configuration, credentials setup, and test skip decision making for unit tests."""
+import platform
+
+WINDOWS_SKIP_MESSAGE = 'Skipping test on Windows'
+
+
+def is_windows():
+    return any(platform.win32_ver())

--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,8 @@ commands =
     flake8 \
         # Ignore F811 redefinition errors in tests (breaks with pytest-mock use)
         # Ignore D103 docstring requirements for tests
-        --ignore F811,D103 \
+        # Ignore D401 imperative mood for module docstrings (was hanging up on integration_test_utils)
+        --ignore F811,D103,D401 \
         test/
 
 [testenv:pylint]


### PR DESCRIPTION
* moving integration tests off of config file and onto environment variables #62 
* consolidating some common helper functions across unit and integration tests into helper modules
* whitelisting the `except` blocks after `typing` imports to exclude them from coverage miss reports
  * I must have missed this when we originally did it, but these are code paths that we expect never to run on most platforms, and without this whitelisting they clutter up the coverage reports and mask actual coverage misses that we need to be aware of.