### PR TITLE
maintenance updates to simplify test framework

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,10 @@ show_missing = True
 
 [mypy]
 ignore_missing_imports = True
+
+[tool:pytest]
+markers =
+    local: mark test as a test that does not require network access
+    unit: mark test as a unit test
+    functional: mark test as a functional test
+    integ: mark a test as an integration test

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,10 +15,10 @@ ignore_missing_imports = True
 
 [tool:pytest]
 markers =
-    local: mark test as a test that does not require network access
-    unit: mark test as a unit test
-    functional: mark test as a functional test
-    integ: mark a test as an integration test
+    local: superset of unit and functional (does not require network access)
+    unit: mark test as a unit test (does not require network access)
+    functional: mark test as a functional test (does not require network access)
+    integ: mark a test as an integration test (requires network access)
 
 [flake8]
 max_complexity = 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,18 @@ markers =
     unit: mark test as a unit test
     functional: mark test as a functional test
     integ: mark a test as an integration test
+
+[flake8]
+max_complexity = 10
+max_line_length = 120
+import_order_style = google
+application_import_names = aws_encryption_sdk_cli
+builtins = raw_input
+ignore =
+    # Ignoring D205 and D400 because of false positives
+    D205, D400,
+    # Ignoring D401 pending discussion of imperative mood
+    D401
+
+[doc8]
+max-line-length = 120

--- a/test/integration/README.rst
+++ b/test/integration/README.rst
@@ -6,7 +6,6 @@ In order to run these integration tests successfully, these things which must be
 
 #. These tests assume that AWS credentials are available in one of the
    `automatically discoverable credential locations`_.
-#. The ``AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_CONTROL`` environment variable must be set to ``RUN``.
 #. The ``AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID`` environment variable must be set to
    a valid `AWS KMS key id`_ that can be used by the available credentials.
 

--- a/test/integration/README.rst
+++ b/test/integration/README.rst
@@ -7,7 +7,7 @@ In order to run these integration tests successfully, these things which must be
 #. These tests assume that AWS credentials are available in one of the
    `automatically discoverable credential locations`_.
 #. The ``AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID`` environment variable must be set to
-   a valid `AWS KMS key id`_ that can be used by the available credentials.
+   a valid `AWS KMS CMK ARN`_ that can be used by the available credentials.
 
 .. _automatically discoverable credential locations: http://boto3.readthedocs.io/en/latest/guide/configuration.html
-.. _AWS KMS key id: http://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html
+.. _AWS KMS CMK ARN: http://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -21,24 +21,12 @@ import six
 
 from aws_encryption_sdk_cli.internal import logging_utils
 
-SKIP_MESSAGE = (
-    'Required environment variables not found. Skipping integration tests.'
-    ' See integration tests README.rst for more information.'
-)
 WINDOWS_SKIP_MESSAGE = 'Skipping test on Windows'
-TEST_CONTROL = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_CONTROL'
 AWS_KMS_KEY_ID = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID'
 
 
 def is_windows():
     return any(platform.win32_ver())
-
-
-def skip_tests():
-    """Only run tests if both required environment variables are found."""
-    test_control = os.environ.get(TEST_CONTROL, None)
-    key_id = os.environ.get(AWS_KMS_KEY_ID, None)
-    return not (test_control == 'RUN' and key_id is not None)
 
 
 def aws_encryption_cli_is_findable():

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -47,6 +47,8 @@ def cmk_arn():
                 AWS_KMS_KEY_ID
             )
         )
+    if 'key' not in arn:
+        raise ValueError('KMS CMK ARN provided for integration tests much be a key not an alias')
     return arn
 
 

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -47,9 +47,9 @@ def cmk_arn():
                 AWS_KMS_KEY_ID
             )
         )
-    if 'key' not in arn:
-        raise ValueError('KMS CMK ARN provided for integration tests much be a key not an alias')
-    return arn
+    if arn.startswith('arn:') and ':alias/' not in arn:
+        return arn
+    raise ValueError('KMS CMK ARN provided for integration tests much be a key not an alias')
 
 
 def encrypt_args_template(metadata=False, caching=False):

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -40,7 +40,14 @@ def aws_encryption_cli_is_findable():
 @pytest.fixture
 def cmk_arn():
     """Retrieves the target CMK ARN from environment variable."""
-    return os.environ.get(AWS_KMS_KEY_ID)
+    arn = os.environ.get(AWS_KMS_KEY_ID, None)
+    if arn is None:
+        raise ValueError(
+            'Environment variable "{}" must be set to a valid KMS CMK ARN for integration tests to run'.format(
+                AWS_KMS_KEY_ID
+            )
+        )
+    return arn
 
 
 def encrypt_args_template(metadata=False, caching=False):

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -24,12 +24,12 @@ import pytest
 import aws_encryption_sdk_cli
 from .integration_test_utils import (
     aws_encryption_cli_is_findable, decrypt_args_template,
-    encrypt_args_template, is_windows, SKIP_MESSAGE, skip_tests,
-    WINDOWS_SKIP_MESSAGE
+    encrypt_args_template, is_windows, WINDOWS_SKIP_MESSAGE
 )
 
+pytestmark = pytest.mark.integ
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
+
 def test_encrypt_with_metadata_output_write_to_file(tmpdir):
     plaintext = tmpdir.join('source_plaintext')
     plaintext.write_binary(os.urandom(1024))
@@ -53,7 +53,6 @@ def test_encrypt_with_metadata_output_write_to_file(tmpdir):
     assert output_metadata['output'] == str(ciphertext)
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_encrypt_with_metadata_full_file_path(tmpdir):
     plaintext_filename = 'source_plaintext'
     plaintext_file = tmpdir.join(plaintext_filename)
@@ -79,7 +78,6 @@ def test_encrypt_with_metadata_full_file_path(tmpdir):
     assert output_metadata['output'] == ciphertext_file_full_path
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_encrypt_with_metadata_output_write_to_stdout(tmpdir, capsys):
     plaintext = tmpdir.join('source_plaintext')
     plaintext.write_binary(os.urandom(1024))
@@ -102,7 +100,6 @@ def test_encrypt_with_metadata_output_write_to_stdout(tmpdir, capsys):
     assert output_metadata['output'] == str(ciphertext)
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_cycle_with_metadata_output_append(tmpdir):
     plaintext = tmpdir.join('source_plaintext')
     plaintext.write_binary(os.urandom(1024))
@@ -139,7 +136,6 @@ def test_cycle_with_metadata_output_append(tmpdir):
     assert 'header_auth' in output_metadata[1]
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 @pytest.mark.parametrize('required_encryption_context', (
     'a',
     'c',
@@ -172,7 +168,6 @@ def test_file_to_file_decrypt_required_encryption_context_success(tmpdir, requir
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 @pytest.mark.parametrize('required_encryption_context', ('a=VALUE_NOT_FOUND', 'KEY_NOT_FOUND'))
 def test_file_to_file_decrypt_required_encryption_context_fail(tmpdir, required_encryption_context):
     plaintext = tmpdir.join('source_plaintext')
@@ -201,7 +196,6 @@ def test_file_to_file_decrypt_required_encryption_context_fail(tmpdir, required_
     assert parsed_metadata['reason'] == 'Missing encryption context key or value'
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_to_file_cycle(tmpdir):
     plaintext = tmpdir.join('source_plaintext')
     ciphertext = tmpdir.join('ciphertext')
@@ -225,7 +219,6 @@ def test_file_to_file_cycle(tmpdir):
 
 
 @pytest.mark.skipif(is_windows(), reason=WINDOWS_SKIP_MESSAGE)
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_to_file_cycle_target_through_symlink(tmpdir):
     plaintext = tmpdir.join('source_plaintext')
     output_dir = tmpdir.mkdir('output')
@@ -250,7 +243,6 @@ def test_file_to_file_cycle_target_through_symlink(tmpdir):
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 @pytest.mark.parametrize('encode, decode', (
     (True, False),
     (False, True),
@@ -298,7 +290,6 @@ def test_file_to_file_base64(tmpdir, encode, decode):
     assert decrypted_plaintext == plaintext_source
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_to_file_cycle_with_caching(tmpdir):
     plaintext = tmpdir.join('source_plaintext')
     ciphertext = tmpdir.join('ciphertext')
@@ -321,7 +312,6 @@ def test_file_to_file_cycle_with_caching(tmpdir):
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_overwrite_source_file_to_file_custom_empty_prefix(tmpdir):
     plaintext_source = os.urandom(2014)
     plaintext = tmpdir.join('source_plaintext')
@@ -341,7 +331,6 @@ def test_file_overwrite_source_file_to_file_custom_empty_prefix(tmpdir):
         assert f.read() == plaintext_source
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_overwrite_source_dir_to_dir_custom_empty_prefix(tmpdir):
     plaintext_source = os.urandom(2014)
     plaintext = tmpdir.join('source_plaintext')
@@ -361,7 +350,6 @@ def test_file_overwrite_source_dir_to_dir_custom_empty_prefix(tmpdir):
         assert f.read() == plaintext_source
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_overwrite_source_file_to_dir_custom_empty_prefix(tmpdir):
     plaintext_source = os.urandom(2014)
     plaintext = tmpdir.join('source_plaintext')
@@ -381,7 +369,6 @@ def test_file_overwrite_source_file_to_dir_custom_empty_prefix(tmpdir):
         assert f.read() == plaintext_source
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_file_to_dir_cycle(tmpdir):
     inner_dir = tmpdir.mkdir('inner')
     plaintext = tmpdir.join('source_plaintext')
@@ -407,7 +394,6 @@ def test_file_to_dir_cycle(tmpdir):
 
 
 @pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_stdin_to_file_to_stdout_cycle(tmpdir):
     ciphertext_file = tmpdir.join('ciphertext')
     plaintext = os.urandom(1024)
@@ -431,7 +417,6 @@ def test_stdin_to_file_to_stdout_cycle(tmpdir):
 
 
 @pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_stdin_stdout_stdin_stdout_cycle():
     plaintext = os.urandom(1024)
 
@@ -452,7 +437,6 @@ def test_stdin_stdout_stdin_stdout_cycle():
 
 
 @pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 @pytest.mark.parametrize('required_encryption_context', ('a=VALUE_NOT_FOUND', 'KEY_NOT_FOUND'))
 def test_file_to_stdout_decrypt_required_encryption_context_fail(tmpdir, required_encryption_context):
     plaintext = tmpdir.join('source_plaintext')
@@ -487,7 +471,6 @@ def test_file_to_stdout_decrypt_required_encryption_context_fail(tmpdir, require
     assert parsed_metadata['reason'] == 'Missing encryption context key or value'
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_dir_to_dir_cycle(tmpdir):
     plaintext_dir = tmpdir.mkdir('plaintext')
     ciphertext_dir = tmpdir.mkdir('ciphertext')
@@ -520,7 +503,6 @@ def test_dir_to_dir_cycle(tmpdir):
             assert filecmp.cmp(plaintext_filename, decrypted_filename)
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_dir_to_dir_cycle_custom_suffix(tmpdir):
     plaintext_dir = tmpdir.mkdir('plaintext')
     ciphertext_dir = tmpdir.mkdir('ciphertext')
@@ -555,7 +537,6 @@ def test_dir_to_dir_cycle_custom_suffix(tmpdir):
             assert filecmp.cmp(plaintext_filename, decrypted_filename)
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_glob_to_dir_cycle(tmpdir):
     plaintext_dir = tmpdir.mkdir('plaintext')
     ciphertext_dir = tmpdir.mkdir('ciphertext')

--- a/test/integration/test_i_key_providers.py
+++ b/test/integration/test_i_key_providers.py
@@ -18,11 +18,12 @@ import pytest
 
 import aws_encryption_sdk_cli
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
-from .integration_test_utils import encrypt_args_template, SKIP_MESSAGE, skip_tests
+from .integration_test_utils import encrypt_args_template
 from .integration_test_utils import kms_redacting_logger_stream  # noqa pylint: disable=unused-import
 
+pytestmark = pytest.mark.integ
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
+
 def test_encrypt_verify_user_agent(tmpdir, kms_redacting_logger_stream):
     plaintext = tmpdir.join('source_plaintext')
     plaintext.write_binary(os.urandom(1024))

--- a/test/integration/test_i_logging_utils.py
+++ b/test/integration/test_i_logging_utils.py
@@ -19,7 +19,8 @@ import pytest
 
 from aws_encryption_sdk_cli.internal import logging_utils
 from .integration_test_utils import cmk_arn, kms_redacting_logger_stream  # noqa pylint: disable=unused-import
-from .integration_test_utils import SKIP_MESSAGE, skip_tests
+
+pytestmark = pytest.mark.integ
 
 
 @pytest.fixture
@@ -28,7 +29,6 @@ def kms_client(cmk_arn):
     return boto3.client('kms', region_name=region)
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_kms_generate_data_key(kms_redacting_logger_stream, kms_client, cmk_arn):
     response = kms_client.generate_data_key(KeyId=cmk_arn, NumberOfBytes=32)
 
@@ -40,7 +40,6 @@ def test_kms_generate_data_key(kms_redacting_logger_stream, kms_client, cmk_arn)
     assert log_output.count(codecs.decode(base64.b64encode(response['CiphertextBlob']), 'utf-8')) == 1
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_kms_encrypt(kms_redacting_logger_stream, kms_client, cmk_arn):
     raw_plaintext = b'some secret data'
     response = kms_client.encrypt(KeyId=cmk_arn, Plaintext=raw_plaintext)
@@ -53,7 +52,6 @@ def test_kms_encrypt(kms_redacting_logger_stream, kms_client, cmk_arn):
     assert log_output.count(codecs.decode(base64.b64encode(response['CiphertextBlob']), 'utf-8')) == 1
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_kms_decrypt(kms_redacting_logger_stream, kms_client, cmk_arn):
     raw_plaintext = b'some secret data'
     encrypt_response = kms_client.encrypt(KeyId=cmk_arn, Plaintext=raw_plaintext)

--- a/test/unit/test_arg_parsing.py
+++ b/test/unit/test_arg_parsing.py
@@ -24,6 +24,8 @@ import aws_encryption_sdk_cli
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError, ParameterParseError
 from aws_encryption_sdk_cli.internal import arg_parsing, identifiers, metadata
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.fixture
 def patch_platform_win32_ver(mocker):
@@ -126,6 +128,7 @@ def test_comment_ignoring_argument_parser_convert_filename(patch_platform_win32_
     assert expected_transform[1] == parsed_line
 
 
+@pytest.mark.functional
 def test_f_comment_ignoring_argument_parser_convert_filename():
     # Actually checks against the current local system
     parser = arg_parsing.CommentIgnoringArgumentParser()

--- a/test/unit/test_aws_encryption_sdk_cli.py
+++ b/test/unit/test_aws_encryption_sdk_cli.py
@@ -26,6 +26,8 @@ from aws_encryption_sdk_cli.internal.logging_utils import _KMSKeyRedactingFormat
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
 from .unit_test_utils import is_windows
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.fixture
 def patch_process_cli_request(mocker):

--- a/test/unit/test_encoding.py
+++ b/test/unit/test_encoding.py
@@ -21,6 +21,8 @@ import pytest
 
 from aws_encryption_sdk_cli.internal.encoding import Base64IO
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 def test_base64io_bad_wrap():
     with pytest.raises(TypeError) as excinfo:

--- a/test/unit/test_io_handling.py
+++ b/test/unit/test_io_handling.py
@@ -24,6 +24,7 @@ import six
 from aws_encryption_sdk_cli.internal import identifiers, io_handling, metadata
 from .unit_test_utils import is_windows, WINDOWS_SKIP_MESSAGE
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 DATA = b'aosidhjf9aiwhj3f98wiaj49c8a3hj49f8uwa0edifja9w843hj98'
 
 
@@ -366,6 +367,7 @@ def test_process_single_operation_file_should_not_write(
     assert not io_handling._stdout.called
 
 
+@pytest.mark.functional
 @pytest.mark.parametrize('interactive, no_overwrite', (
     (False, False),
     (False, True),

--- a/test/unit/test_key_providers.py
+++ b/test/unit/test_key_providers.py
@@ -19,6 +19,8 @@ from aws_encryption_sdk_cli import key_providers
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_deepcopy(mocker):

--- a/test/unit/test_logging_utils.py
+++ b/test/unit/test_logging_utils.py
@@ -18,6 +18,8 @@ import pytest
 
 from aws_encryption_sdk_cli.internal import logging_utils
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_logging_levels(mocker):

--- a/test/unit/test_master_key_parsing.py
+++ b/test/unit/test_master_key_parsing.py
@@ -23,6 +23,8 @@ from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal import logging_utils, master_key_parsing
 from aws_encryption_sdk_cli.key_providers import aws_kms_master_key_provider
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_load_master_key_provider(mocker):

--- a/test/unit/test_metadata.py
+++ b/test/unit/test_metadata.py
@@ -22,6 +22,7 @@ import pytest
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal import metadata
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 GOOD_INIT_KWARGS = dict(
     suppress_output=False
 )

--- a/tox.ini
+++ b/tox.ini
@@ -35,9 +35,9 @@ deps =
     pytest-sugar
     coverage
 commands =
-    local: pytest --cov aws_encryption_sdk_cli -m local {posargs}
-    integ: pytest --cov aws_encryption_sdk_cli -m integ {posargs}
-    all: pytest --cov aws_encryption_sdk_cli {posargs}
+    local: pytest --cov aws_encryption_sdk_cli -m local -l {posargs}
+    integ: pytest --cov aws_encryption_sdk_cli -m integ -l {posargs}
+    all: pytest --cov aws_encryption_sdk_cli -l {posargs}
 
 # mypy
 [testenv:mypy-coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,7 @@ deps =
     flake8
     flake8-docstrings
     flake8-import-order
+    flake8-print>=3.0.1
 commands =
     flake8 \
         src/aws_encryption_sdk_cli/ \

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
 envlist =
-    py27, py34, py35, py36,
-    mypy-py2, mypy-py3,
+    py{27,34,35,36}-{local,integ},
+    mypy-py{2,3},
     bandit, doc8, readme, docs,
     flake8, pylint,
     flake8-tests, pylint-tests
 
-# Additional environments:
+# Additional test environments:
 # vulture :: Runs vulture. Prone to false-positives.
 # linters :: Runs all linters over all source code.
 # linters-tests :: Runs all linters over all tests.
 
-# Additional environments:
+# Operational helper environments:
 # docs :: Builds Sphinx documentation.
 # serve-docs :: Starts local webserver to serve built documentation.
 # park :: Builds name-parking packages using pypi-parker.
@@ -21,8 +21,6 @@ envlist =
 
 [testenv]
 passenv = 
-    # Enables or disables integration tests ('RUN' enables)
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_CONTROL \
     # Identifies AWS KMS key id to use in integration tests
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID \
     # Pass through AWS credentials
@@ -34,13 +32,25 @@ deps =
     pytest-catchlog
     pytest-cov
     pytest-mock
+    pytest-sugar
     coverage
 commands =
-    coverage run -m pytest \
-        --cov aws_encryption_sdk_cli \
-        {posargs}
+    local: pytest --cov aws_encryption_sdk_cli -m local {posargs}
+    integ: pytest --cov aws_encryption_sdk_cli -m integ {posargs}
+    all: pytest --cov aws_encryption_sdk_cli {posargs}
 
 # mypy
+[testenv:mypy-coverage]
+commands =
+    # Make mypy linecoverage report readable by coverage
+    python -c \
+        "t = open('.coverage', 'w');\
+        c = open('build/coverage.json').read();\
+        t.write('!coverage.py: This is a private format, don\'t read it directly!\n');\
+        t.write(c);\
+        t.close()"
+    coverage report -m
+
 [testenv:mypy-py3]
 basepython = python3
 deps =
@@ -50,14 +60,7 @@ commands =
     python -m mypy \
         --linecoverage-report build \
         src/aws_encryption_sdk_cli/
-    # Make mypy linecoverage report readable by coverage
-    python -c \
-        "t = open('.coverage', 'w');\
-        c = open('build/coverage.json').read();\
-        t.write('!coverage.py: This is a private format, don\'t read it directly!\n');\
-        t.write(c);\
-        t.close()"
-    coverage report -m
+    {[testenv:mypy-coverage]commands}
 
 [testenv:mypy-py2]
 basepython = python3
@@ -69,14 +72,7 @@ commands =
         --py2 \
         --linecoverage-report build \
         src/aws_encryption_sdk_cli/
-    # Make mypy linecoverage report readable by coverage
-    python -c \
-        "t = open('.coverage', 'w');\
-        c = open('build/coverage.json').read();\
-        t.write('!coverage.py: This is a private format, don\'t read it directly!\n');\
-        t.write(c);\
-        t.close()"
-    coverage report -m
+    {[testenv:mypy-coverage]commands}
 
 # Linters
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -222,20 +222,3 @@ deps =
 commands =
     {[testenv:build]commands}
     twine upload --skip-existing --repository pypi dist/*
-
-# Flake8 Configuration
-[flake8]
-max_complexity = 10
-max_line_length = 120
-import_order_style = google
-application_import_names = aws_encryption_sdk_cli
-builtins = raw_input
-ignore =
-    # Ignoring D205 and D400 because of false positives
-    D205, D400,
-    # Ignoring D401 pending discussion of imperative mood
-    D401
-
-# Doc8 Configuration
-[doc8]
-max-line-length = 120


### PR DESCRIPTION
* consolidating common 
* cleaning up integration test handling #67
  * marking all tests/modules as unit, functional, local (no network access required), and/or integration (network access required)
  * changing test handling to run local/integ tests as separate tox testenvs rather than skipping integration tests if a specific environment variable is not found : this makes it much clearer if integration tests fail, distinct from local tests)
* adding flake8-print #22
* adding more useful error output if KMS key id environment variable is not set
* adding requirement that KMS key id environment variable is an CMK ARN (required for logging tests without also requiring DescribeKey access)