### PR TITLE
Adding AppVeyor CI integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@ aws-encryption-sdk-cli
 .. image:: https://travis-ci.org/awslabs/aws-encryption-sdk-cli.svg?branch=master
    :target: https://travis-ci.org/awslabs/aws-encryption-sdk-cli
 
+.. image:: https://ci.appveyor.com/api/projects/status/awslabs/aws-encryption-sdk-cli/branch/master?svg=true
+   :target: https://ci.appveyor.com/api/projects/status/awslabs/aws-encryption-sdk-cli/branch/master?svg=true
+
 This command line tool can be used to encrypt and decrypt files and directories using the `AWS Encryption SDK`_.
 
 The latest full documentation can be found at `Read the Docs`_.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,11 @@ environment:
       TOXENV: "py36-integ"
 
 install:
-  - "%PYTHON%\\python.exe -m pip install wheel tox"
+  # Prepend newly installed Python to the PATH of this build
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  # Check the Python version to verify the correct version was installed
+  - "python --version"
+  - "python -m pip install wheel tox"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,55 @@
+# https://packaging.python.org/guides/supporting-windows-using-appveyor/
+
+environment:
+
+  matrix:
+    # The only test we perform on Windows are our actual code tests. All linting, static
+    # analysis, etc are only run on Linux (via Travis CI).
+
+    # Python 2.7
+    - PYTHON: "C:\\Python27"
+      TOXENV: "py27-local"
+    - PYTHON: "C:\\Python27"
+      TOXENV: "py27-integ"
+    - PYTHON: "C:\\Python27-x64"
+      TOXENV: "py27-local"
+    - PYTHON: "C:\\Python27-x64"
+      TOXENV: "py27-integ"
+
+    # Python 3.4
+    - PYTHON: "C:\\Python34"
+      TOXENV: "py34-local"
+    - PYTHON: "C:\\Python34"
+      TOXENV: "py34-integ"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: "1"
+      TOXENV: "py34-local"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: "1"
+      TOXENV: "py34-integ"
+
+    # Python 3.5
+    - PYTHON: "C:\\Python35"
+      TOXENV: "py35-local"
+    - PYTHON: "C:\\Python35"
+      TOXENV: "py35-integ"
+    - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py35-local"
+    - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py35-integ"
+
+    # Python 3.6
+    - PYTHON: "C:\\Python36"
+      TOXENV: "py36-local"
+    - PYTHON: "C:\\Python36"
+      TOXENV: "py36-integ"
+    - PYTHON: "C:\\Python36-x64"
+      TOXENV: "py36-local"
+    - PYTHON: "C:\\Python36-x64"
+      TOXENV: "py36-integ"
+
+install:
+  - "%PYTHON%\\python.exe -m pip install wheel tox"
+
+test_script:
+  - "tox"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,5 +51,7 @@ environment:
 install:
   - "%PYTHON%\\python.exe -m pip install wheel tox"
 
+build: off
+
 test_script:
   - "tox"

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -52,7 +52,7 @@ def cmk_arn():
     raise ValueError('KMS CMK ARN provided for integration tests much be a key not an alias')
 
 
-def encrypt_args_template(metadata=False, caching=False):
+def encrypt_args_template(metadata=False, caching=False, encode=False, decode=False):
     template = '-e -i {source} -o {target} --encryption-context a=b c=d -m key=' + cmk_arn()
     if metadata:
         template += ' {metadata}'
@@ -60,15 +60,23 @@ def encrypt_args_template(metadata=False, caching=False):
         template += ' -S'
     if caching:
         template += ' --caching capacity=10 max_age=60.0'
+    if encode:
+        template += ' --encode'
+    if decode:
+        template += ' --decode'
     return template
 
 
-def decrypt_args_template(metadata=False):
+def decrypt_args_template(metadata=False, encode=False, decode=False):
     template = '-d -i {source} -o {target}'
     if metadata:
         template += ' {metadata}'
     else:
         template += ' -S'
+    if encode:
+        template += ' --encode'
+    if decode:
+        template += ' --decode'
     return template
 
 

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -42,7 +42,7 @@ def test_encrypt_with_metadata_output_write_to_file(tmpdir):
         metadata='--metadata-output ' + str(metadata)
     )
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     raw_metadata = metadata.read()
     output_metadata = json.loads(raw_metadata)
@@ -70,7 +70,7 @@ def test_encrypt_with_metadata_full_file_path(tmpdir):
     )
 
     with tmpdir.as_cwd():
-        aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
+        aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     raw_metadata = metadata.read()
     output_metadata = json.loads(raw_metadata)
@@ -89,7 +89,7 @@ def test_encrypt_with_metadata_output_write_to_stdout(tmpdir, capsys):
         metadata='--metadata-output -'
     )
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     out, _err = capsys.readouterr()
     output_metadata = json.loads(out)
@@ -118,8 +118,8 @@ def test_cycle_with_metadata_output_append(tmpdir):
         metadata='--metadata-output ' + str(metadata)
     )
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     output_metadata = [json.loads(line) for line in metadata.readlines()]
     for line in output_metadata:
@@ -162,8 +162,8 @@ def test_file_to_file_decrypt_required_encryption_context_success(tmpdir, requir
         target=str(decrypted)
     ) + ' --encryption-context ' + required_encryption_context
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
@@ -186,8 +186,8 @@ def test_file_to_file_decrypt_required_encryption_context_fail(tmpdir, required_
         metadata=' --metadata-output ' + str(metadata_file)
     ) + ' --encryption-context ' + required_encryption_context
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     assert not decrypted.isfile()
     raw_metadata = metadata_file.read()
@@ -212,8 +212,8 @@ def test_file_to_file_cycle(tmpdir):
         target=str(decrypted)
     )
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
@@ -237,8 +237,8 @@ def test_file_to_file_cycle_target_through_symlink(tmpdir):
         target=str(decrypted)
     )
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
@@ -270,7 +270,7 @@ def test_file_to_file_base64(tmpdir, encode, decode):
         target=str(decrypted)
     ) + decrypt_flag
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     if encode and not decode:
         with open(str(ciphertext_a), 'rb') as ct_a, open(str(ciphertext_b), 'wb') as ct_b:
@@ -282,7 +282,7 @@ def test_file_to_file_base64(tmpdir, encode, decode):
     else:
         shutil.copy2(str(ciphertext_a), str(ciphertext_b))
 
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     with open(str(decrypted), 'rb') as f:
         decrypted_plaintext = f.read()
@@ -306,8 +306,8 @@ def test_file_to_file_cycle_with_caching(tmpdir):
         target=str(decrypted)
     )
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
@@ -323,7 +323,7 @@ def test_file_overwrite_source_file_to_file_custom_empty_prefix(tmpdir):
         target=str(plaintext)
     ) + ' --suffix'
 
-    test_result = aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
+    test_result = aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     assert test_result == 'Destination and source cannot be the same'
 
@@ -342,7 +342,7 @@ def test_file_overwrite_source_dir_to_dir_custom_empty_prefix(tmpdir):
         target=str(tmpdir)
     ) + ' --suffix'
 
-    test_result = aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
+    test_result = aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     assert test_result == 'Destination and source cannot be the same'
 
@@ -361,7 +361,7 @@ def test_file_overwrite_source_file_to_dir_custom_empty_prefix(tmpdir):
         target=str(tmpdir)
     ) + ' --suffix'
 
-    test_result = aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
+    test_result = aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     assert test_result is None
 
@@ -386,9 +386,9 @@ def test_file_to_dir_cycle(tmpdir):
         target=str(decrypted)
     )
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     assert os.path.isfile(str(ciphertext))
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
@@ -407,10 +407,10 @@ def test_stdin_to_file_to_stdout_cycle(tmpdir):
         target='-'
     )
 
-    proc = Popen(shlex.split(encrypt_args), stdout=PIPE, stdin=PIPE, stderr=PIPE)
+    proc = Popen(shlex.split(encrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
     _stdout, _stderr = proc.communicate(input=plaintext)
 
-    proc = Popen(shlex.split(decrypt_args), stdout=PIPE, stdin=PIPE, stderr=PIPE)
+    proc = Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
     decrypted_stdout, _stderr = proc.communicate()
 
     assert decrypted_stdout == plaintext
@@ -428,9 +428,9 @@ def test_stdin_stdout_stdin_stdout_cycle():
         source='-',
         target='-'
     )
-    proc = Popen(shlex.split(encrypt_args), stdout=PIPE, stdin=PIPE, stderr=PIPE)
+    proc = Popen(shlex.split(encrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
     ciphertext, _stderr = proc.communicate(input=plaintext)
-    proc = Popen(shlex.split(decrypt_args), stdout=PIPE, stdin=PIPE, stderr=PIPE)
+    proc = Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
     decrypted_stdout, _stderr = proc.communicate(input=ciphertext)
 
     assert decrypted_stdout == plaintext
@@ -454,8 +454,8 @@ def test_file_to_stdout_decrypt_required_encryption_context_fail(tmpdir, require
         metadata=' --metadata-output ' + str(metadata_file)
     ) + ' --encryption-context ' + required_encryption_context
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
-    proc = Popen(shlex.split(decrypt_args), stdout=PIPE, stdin=PIPE, stderr=PIPE)
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    proc = Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
     decrypted_output, stderr = proc.communicate()
 
     # Verify that no output was written
@@ -490,8 +490,8 @@ def test_dir_to_dir_cycle(tmpdir):
         target=str(decrypted_dir)
     ) + ' -r'
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     for base_dir, _dirs, filenames in os.walk(str(plaintext_dir)):
         for file in filenames:
@@ -524,8 +524,8 @@ def test_dir_to_dir_cycle_custom_suffix(tmpdir):
         target=str(decrypted_dir)
     ) + ' -r' + ' --suffix ' + decrypt_suffix
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     for base_dir, _dirs, filenames in os.walk(str(plaintext_dir)):
         for file in filenames:
@@ -556,8 +556,8 @@ def test_glob_to_dir_cycle(tmpdir):
         target=str(decrypted_dir)
     ) + ' -r'
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
-    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
     for base_dir, _dirs, filenames in os.walk(str(plaintext_dir)):
         for file in filenames:

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -398,42 +398,42 @@ def test_stdin_to_file_to_stdout_cycle(tmpdir):
     ciphertext_file = tmpdir.join('ciphertext')
     plaintext = os.urandom(1024)
 
-    encrypt_args = 'aws-encryption-cli ' + encrypt_args_template().format(
+    encrypt_args = 'aws-encryption-cli ' + encrypt_args_template(decode=True).format(
         source='-',
         target=str(ciphertext_file)
     )
-    decrypt_args = 'aws-encryption-cli ' + decrypt_args_template().format(
+    decrypt_args = 'aws-encryption-cli ' + decrypt_args_template(encode=True).format(
         source=str(ciphertext_file),
         target='-'
     )
 
     proc = Popen(shlex.split(encrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
-    _stdout, _stderr = proc.communicate(input=plaintext)
+    _stdout, _stderr = proc.communicate(input=base64.b64encode(plaintext))
 
     proc = Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
     decrypted_stdout, _stderr = proc.communicate()
 
-    assert decrypted_stdout == plaintext
+    assert base64.b64decode(decrypted_stdout) == plaintext
 
 
 @pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
 def test_stdin_stdout_stdin_stdout_cycle():
     plaintext = os.urandom(1024)
 
-    encrypt_args = 'aws-encryption-cli ' + encrypt_args_template().format(
+    encrypt_args = 'aws-encryption-cli ' + encrypt_args_template(decode=True, encode=True).format(
         source='-',
         target='-'
     )
-    decrypt_args = 'aws-encryption-cli ' + decrypt_args_template().format(
+    decrypt_args = 'aws-encryption-cli ' + decrypt_args_template(decode=True, encode=True).format(
         source='-',
         target='-'
     )
     proc = Popen(shlex.split(encrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
-    ciphertext, _stderr = proc.communicate(input=plaintext)
+    ciphertext, _stderr = proc.communicate(input=base64.b64encode(plaintext))
     proc = Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
     decrypted_stdout, _stderr = proc.communicate(input=ciphertext)
 
-    assert decrypted_stdout == plaintext
+    assert base64.b64decode(decrypted_stdout) == plaintext
 
 
 @pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')

--- a/test/integration/test_i_key_providers.py
+++ b/test/integration/test_i_key_providers.py
@@ -19,7 +19,7 @@ import pytest
 import aws_encryption_sdk_cli
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
 from .integration_test_utils import encrypt_args_template
-from .integration_test_utils import kms_redacting_logger_stream  # noqa pylint: disable=unused-import
+from .integration_test_utils import is_windows, kms_redacting_logger_stream  # noqa pylint: disable=unused-import
 
 pytestmark = pytest.mark.integ
 
@@ -34,7 +34,7 @@ def test_encrypt_verify_user_agent(tmpdir, kms_redacting_logger_stream):
         target=str(ciphertext)
     ) + ' -vvvv'
 
-    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args))
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     all_logs = kms_redacting_logger_stream.getvalue()
     assert USER_AGENT_SUFFIX in all_logs


### PR DESCRIPTION
Adding AppVeyor CI integration #91. Also required some fixes to make integration tests run properly on Windows.

We don't have AppVeyor granted access to awslabs yet, but here's the latest run from my branch: https://ci.appveyor.com/project/mattsb42-aws/aws-encryption-sdk-cli/build/1.0.15