### PR TITLE
reworking build_same_files_and_dirs helper to explicitly cover all return cases

### DIFF
--- a/test/unit/test_aws_encryption_sdk_cli.py
+++ b/test/unit/test_aws_encryption_sdk_cli.py
@@ -75,15 +75,15 @@ def build_same_files_and_dirs(tmpdir, source_is_symlink, dest_is_symlink, use_fi
         real = tmpdir.mkdir('real')
     link = tmpdir.join('link')
 
-    if not (source_is_symlink or dest_is_symlink):
-        return str(real), str(real)
+    if source_is_symlink or dest_is_symlink:
+        os.symlink(str(real), str(link))
 
-    os.symlink(str(real), str(link))
+        if source_is_symlink:
+            return str(link), str(real)
+        elif dest_is_symlink:
+            return str(real), str(link)
 
-    if source_is_symlink:
-        return str(link), str(real)
-    elif dest_is_symlink:
-        return str(real), str(link)
+    return str(real), str(real)
 
 
 def build_same_file_and_dir_test_cases():


### PR DESCRIPTION
Addresses #139 

I don't think this necessarily merits a version bump or additional release since it only affects the tests.