### PR TITLE
removing pytest-sugar pending https://github.com/Frozenball/pytest-sugar/pull/133

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,11 +28,9 @@ passenv =
 sitepackages = False
 deps =
     mock
-    pytest>3.3.0
+    pytest>=3.3.1
     pytest-cov
     pytest-mock
-    pytest-sugar
-    coverage
 commands =
     local: pytest --cov aws_encryption_sdk_cli -m local -l {posargs}
     integ: pytest --cov aws_encryption_sdk_cli -m integ -l {posargs}


### PR DESCRIPTION
`pytest` `3.4.0` introduced a breaking change that broke `pytest-sugar`. A fix is pending for that now, but turning it off for now a) because the PR is not merged and I don't want to block on their release cycle, and b) because most of why I added `pytest-sugar` in the first place (rolling % completion of test suite) was added into `pytest` itself in `3.3.0`.

Also did a bit of minor cleanup of the test requirements: `coverage` will always be pulled in by `pytest-cov`, so no need to specify that directly, and updating the `pytest` version requirement to be consistent with https://github.com/awslabs/aws-encryption-sdk-python .