### PR TITLE
blacklist mypy 0.570 and 0.580

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,9 @@ passenv =
     # Identifies AWS KMS key id to use in integration tests
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID \
     # Pass through AWS credentials
-    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
+    # Pass through AWS profile name (useful for local testing)
+    AWS_PROFILE
 sitepackages = False
 deps =
     mock
@@ -48,27 +50,33 @@ commands =
         t.close()"
     coverage report -m
 
-[testenv:mypy-py3]
+[testenv:mypy-common]
 basepython = python3
 deps =
     coverage
-    mypy
+    mypy!=0.570,!=0.580
+    mypy_extensions
+    typing>=3.6.2
+
+[testenv:mypy-py3]
+basepython = {[testenv:mypy-common]basepython}
+deps = {[testenv:mypy-common]deps}
 commands =
     python -m mypy \
         --linecoverage-report build \
-        src/aws_encryption_sdk_cli/
+        src/aws_encryption_sdk_cli/ \
+        {posargs}
     {[testenv:mypy-coverage]commands}
 
 [testenv:mypy-py2]
-basepython = python3
-deps =
-    coverage
-    mypy
+basepython = {[testenv:mypy-common]basepython}
+deps = {[testenv:mypy-common]deps}
 commands =
     python -m mypy \
         --py2 \
         --linecoverage-report build \
-        src/aws_encryption_sdk_cli/
+        src/aws_encryption_sdk_cli/ \
+        {posargs}
     {[testenv:mypy-coverage]commands}
 
 # Linters


### PR DESCRIPTION

*Issue #, if available:* #147 

*Description of changes:*
* Single-source mypy basepython and dependencies
* Blacklist mypy 0.570 and 0.580
* Add passthrough for testing environment variable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
