### PR TITLE
Blacken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,9 @@ matrix:
       env: TOXENV=flake8-tests
     - python: 3.6
       env: TOXENV=pylint-tests
+    - python: 3.6
+      env: TOXENV=black-check
+    - python: 3.6
+      env: TOXENV=isort-check
 install: pip install tox
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,14 @@ aws-encryption-sdk-cli
    :target: https://pypi.python.org/pypi/aws-encryption-sdk-cli
    :alt: Latest Version
 
+.. image:: https://img.shields.io/pypi/pyversions/base64io.svg
+   :target: https://pypi.python.org/pypi/base64io
+   :alt: Supported Python Versions
+
+.. image:: https://img.shields.io/badge/code_style-black-000000.svg
+   :target: https://github.com/ambv/black
+   :alt: Code style: black
+
 .. image:: https://readthedocs.org/projects/aws-encryption-sdk-cli/badge/
    :target: https://aws-encryption-sdk-cli.readthedocs.io/en/stable/
    :alt: Documentation Status

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,66 +5,71 @@ import os
 import re
 from datetime import datetime
 
-VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
+VERSION_RE = re.compile(r"""__version__ = ['"]([0-9.]+)['"]""")
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 def read(*args):
     """Reads complete file contents."""
-    return io.open(os.path.join(HERE, *args), encoding='utf-8').read()
+    return io.open(os.path.join(HERE, *args), encoding="utf-8").read()
 
 
 def get_release():
     """Reads the release (full three-part version number) from this module."""
-    init = read('..', 'src', 'aws_encryption_sdk_cli', 'internal', 'identifiers.py')
+    init = read("..", "src", "aws_encryption_sdk_cli", "internal", "identifiers.py")
     return VERSION_RE.search(init).group(1)
 
 
 def get_version():
     """Reads the version (MAJOR.MINOR) from this module."""
     _release = get_release()
-    split_version = _release.split('.')
+    split_version = _release.split(".")
     if len(split_version) == 3:
-        return '.'.join(split_version[:2])
+        return ".".join(split_version[:2])
     return _release
 
 
-project = u'aws-encryption-sdk-python-cli'
+project = u"aws-encryption-sdk-python-cli"
 version = get_version()
 release = get_release()
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
-              'sphinx.ext.intersphinx', 'sphinx.ext.todo',
-              'sphinx.ext.coverage', 'sphinx.ext.autosummary',
-              'sphinx.ext.napoleon']
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+]
 napoleon_include_special_with_doc = False
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
-source_suffix = '.rst'  # The suffix of source filenames.
-master_doc = 'index'  # The master toctree document.
+source_suffix = ".rst"  # The suffix of source filenames.
+master_doc = "index"  # The master toctree document.
 
-copyright = u'%s, Amazon' % datetime.now().year  # pylint: disable=redefined-builtin
+copyright = u"%s, Amazon" % datetime.now().year  # pylint: disable=redefined-builtin
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.
-exclude_trees = ['_build']
+exclude_trees = ["_build"]
 
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 autoclass_content = "both"
-autodoc_default_flags = ['show-inheritance', 'members']
-autodoc_member_order = 'bysource'
+autodoc_default_flags = ["show-inheritance", "members"]
+autodoc_member_order = "bysource"
 
-html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
-htmlhelp_basename = '%sdoc' % project
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+htmlhelp_basename = "%sdoc" % project
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {"http://docs.python.org/": None}
 
 # autosummary
 autosummary_generate = True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,9 +1,9 @@
 # pylint: disable=invalid-name
 """Sphinx configuration."""
-from datetime import datetime
 import io
 import os
 import re
+from datetime import datetime
 
 VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 HERE = os.path.abspath(os.path.dirname(__file__))

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,4 +37,6 @@ max-line-length = 120
 
 [isort]
 line_length = 120
+not_skip = __init__.py
 known_first_party = aws_encryption_sdk_cli
+known_third_party = attr,aws_encryption_sdk,boto3,botocore,mock,pkg_resources,pytest,pytest_mock,setuptools,six

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,4 @@ max-line-length = 120
 
 [isort]
 line_length = 120
+known_first_party = aws_encryption_sdk_cli

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,9 @@ max-line-length = 120
 
 [isort]
 line_length = 120
+# https://github.com/timothycrosley/isort#multi-line-output-modes
+multi_line_output = 5
+balanced_wrapping = True
 not_skip = __init__.py
 known_first_party = aws_encryption_sdk_cli
 known_third_party = attr,aws_encryption_sdk,boto3,botocore,mock,pkg_resources,pytest,pytest_mock,setuptools,six

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,8 @@ line_length = 120
 # https://github.com/timothycrosley/isort#multi-line-output-modes
 multi_line_output = 3
 include_trailing_comma = True
-balanced_wrapping = True
+force_grid_wrap = 0
+combine_as_imports = True
 not_skip = __init__.py
 known_first_party = aws_encryption_sdk_cli
 known_third_party = attr,aws_encryption_sdk,boto3,botocore,mock,pkg_resources,pytest,pytest_mock,setuptools,six

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,9 @@ ignore =
     # Ignoring D401 pending discussion of imperative mood
     D401,
     # E203 is not PEP8 compliant https://github.com/ambv/black#slices
-    E203
+    E203,
+    # W503 is not PEP8 compliant https://github.com/ambv/black#line-breaks--binary-operators
+    W503
 
 [doc8]
 max-line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,6 @@ ignore =
 
 [doc8]
 max-line-length = 120
+
+[isort]
+line_length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ max-line-length = 120
 [isort]
 line_length = 120
 # https://github.com/timothycrosley/isort#multi-line-output-modes
-multi_line_output = 5
+multi_line_output = 3
 balanced_wrapping = True
 not_skip = __init__.py
 known_first_party = aws_encryption_sdk_cli

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,9 @@ ignore =
     # Ignoring D205 and D400 because of false positives
     D205, D400,
     # Ignoring D401 pending discussion of imperative mood
-    D401
+    D401,
+    # E203 is not PEP8 compliant https://github.com/ambv/black#slices
+    E203
 
 [doc8]
 max-line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ max-line-length = 120
 line_length = 120
 # https://github.com/timothycrosley/isort#multi-line-output-modes
 multi_line_output = 3
+include_trailing_comma = True
 balanced_wrapping = True
 not_skip = __init__.py
 known_first_party = aws_encryption_sdk_cli

--- a/setup.py
+++ b/setup.py
@@ -5,64 +5,61 @@ import re
 
 from setuptools import find_packages, setup
 
-VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
+VERSION_RE = re.compile(r"""__version__ = ['"]([0-9.]+)['"]""")
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 def read(*args):
     """Reads complete file contents."""
-    return io.open(os.path.join(HERE, *args), encoding='utf-8').read()
+    return io.open(os.path.join(HERE, *args), encoding="utf-8").read()
 
 
 def get_version():
     """Reads the version from this module."""
-    init = read('src', 'aws_encryption_sdk_cli', 'internal', 'identifiers.py')
+    init = read("src", "aws_encryption_sdk_cli", "internal", "identifiers.py")
     return VERSION_RE.search(init).group(1)
 
 
 def get_requirements():
     """Reads the requirements file."""
-    requirements = read('requirements.txt')
+    requirements = read("requirements.txt")
     return [r for r in requirements.strip().splitlines()]
 
 
 setup(
-    name='aws-encryption-sdk-cli',
+    name="aws-encryption-sdk-cli",
     version=get_version(),
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    url='http://aws-encryption-sdk-cli.readthedocs.io/en/latest/',
-    author='Amazon Web Services',
-    author_email='aws-cryptools@amazon.com',
-    maintainer='Amazon Web Services',
+    packages=find_packages("src"),
+    package_dir={"": "src"},
+    url="http://aws-encryption-sdk-cli.readthedocs.io/en/latest/",
+    author="Amazon Web Services",
+    author_email="aws-cryptools@amazon.com",
+    maintainer="Amazon Web Services",
     description=(
-        'This command line tool can be used to encrypt and decrypt files and directories using the AWS Encryption SDK.'
+        "This command line tool can be used to encrypt and decrypt files and directories using the AWS Encryption SDK."
     ),
-    long_description=read('README.rst'),
-    keywords='aws-encryption-sdk aws kms encryption cli command line',
-    license='Apache License 2.0',
+    long_description=read("README.rst"),
+    keywords="aws-encryption-sdk aws kms encryption cli command line",
+    license="Apache License 2.0",
     install_requires=get_requirements(),
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Natural Language :: English',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Security',
-        'Topic :: Security :: Cryptography'
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Topic :: Security",
+        "Topic :: Security :: Cryptography",
     ],
     entry_points={
-        'console_scripts': [
-            'aws-encryption-cli=aws_encryption_sdk_cli:cli'
-        ],
-        'aws_encryption_sdk_cli.master_key_providers':
-            'aws-kms=aws_encryption_sdk_cli.key_providers:aws_kms_master_key_provider'
-    }
+        "console_scripts": ["aws-encryption-cli=aws_encryption_sdk_cli:cli"],
+        "aws_encryption_sdk_cli.master_key_providers": "aws-kms=aws_encryption_sdk_cli.key_providers:aws_kms_master_key_provider",  # noqa
+    },
 )

--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -11,12 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """AWS Encryption SDK CLI."""
-from argparse import Namespace  # noqa pylint: disable=unused-import
 import copy
 import glob
 import logging
 import os
 import traceback
+from argparse import Namespace  # noqa pylint: disable=unused-import
 
 import aws_encryption_sdk
 from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager  # noqa pylint: disable=unused-import
@@ -29,7 +29,6 @@ from aws_encryption_sdk_cli.internal.io_handling import IOHandler, output_filena
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME, setup_logger
 from aws_encryption_sdk_cli.internal.master_key_parsing import build_crypto_materials_manager_from_args
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter  # noqa pylint: disable=unused-import
-
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import List, Optional, Union  # noqa pylint: disable=unused-import

--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -23,6 +23,7 @@ from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager  #
 
 from aws_encryption_sdk_cli.exceptions import AWSEncryptionSDKCLIError, BadUserArgumentError
 from aws_encryption_sdk_cli.internal.arg_parsing import parse_args
+
 # convenience import separated from other imports from this module to avoid over-application of linting override
 from aws_encryption_sdk_cli.internal.identifiers import __version__  # noqa
 from aws_encryption_sdk_cli.internal.io_handling import IOHandler, output_filename
@@ -37,7 +38,7 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-__all__ = ('cli', 'process_cli_request', 'stream_kwargs_from_args')
+__all__ = ("cli", "process_cli_request", "stream_kwargs_from_args")
 _LOGGER = logging.getLogger(LOGGER_NAME)
 
 
@@ -52,9 +53,9 @@ def _expand_sources(source):
     """
     all_sources = glob.glob(source)
     if not all_sources:
-        raise BadUserArgumentError('Invalid source.  Must be a valid pathname pattern or stdin (-)')
-    _LOGGER.debug('Requested source: %s', source)
-    _LOGGER.debug('Expanded source: %s', all_sources)
+        raise BadUserArgumentError("Invalid source.  Must be a valid pathname pattern or stdin (-)")
+    _LOGGER.debug("Requested source: %s", source)
+    _LOGGER.debug("Expanded source: %s", all_sources)
     return all_sources
 
 
@@ -65,9 +66,9 @@ def _catch_bad_destination_requests(destination):
     :param str destination: Identifier for the destination (filesystem path or ``-`` for stdout)
     :raises BadUserArgument: if destination is a file in a directory that does not already exist
     """
-    if destination != '-' and not os.path.isdir(destination):
+    if destination != "-" and not os.path.isdir(destination):
         if not os.path.isdir(os.path.realpath(os.path.dirname(destination))):
-            raise BadUserArgumentError('If destination is a file, the immediate parent directory must already exist.')
+            raise BadUserArgumentError("If destination is a file, the immediate parent directory must already exist.")
 
 
 def _catch_bad_stdin_stdout_requests(source, destination):
@@ -80,12 +81,12 @@ def _catch_bad_stdin_stdout_requests(source, destination):
     :raises BadUserArgument: if source and destination are the same
     :raises BadUserArgument: if source is stdin and destination is a directory
     """
-    acting_as_pipe = destination == '-' and source == '-'
+    acting_as_pipe = destination == "-" and source == "-"
     if not acting_as_pipe and os.path.realpath(source) == os.path.realpath(destination):
-        raise BadUserArgumentError('Destination and source cannot be the same')
+        raise BadUserArgumentError("Destination and source cannot be the same")
 
-    if source == '-' and os.path.isdir(destination):
-        raise BadUserArgumentError('Destination may not be a directory when source is stdin')
+    if source == "-" and os.path.isdir(destination):
+        raise BadUserArgumentError("Destination may not be a directory when source is stdin")
 
 
 def _catch_bad_file_and_directory_requests(expanded_sources, destination):
@@ -99,13 +100,13 @@ def _catch_bad_file_and_directory_requests(expanded_sources, destination):
     :raises BadUserArgumentError: if source contains a directory and destination is not an existing directory
     """
     if len(expanded_sources) > 1 and not os.path.isdir(destination):
-        raise BadUserArgumentError('If operating on multiple sources, destination must be an existing directory')
+        raise BadUserArgumentError("If operating on multiple sources, destination must be an existing directory")
 
     for _source in expanded_sources:
         if os.path.isdir(_source):
             if not os.path.isdir(destination):
                 raise BadUserArgumentError(
-                    'If operating on a source directory, destination must be an existing directory'
+                    "If operating on a source directory, destination must be an existing directory"
                 )
 
 
@@ -124,9 +125,9 @@ def _catch_bad_metadata_file_requests(metadata_output, source, destination):
     if metadata_output.suppress_output:
         return
 
-    if metadata_output.output_file == '-':
-        if destination == '-':
-            raise BadUserArgumentError('Metadata output cannot be stdout when output is stdout')
+    if metadata_output.output_file == "-":
+        if destination == "-":
+            raise BadUserArgumentError("Metadata output cannot be stdout when output is stdout")
         return
 
     real_source = os.path.realpath(source)
@@ -134,16 +135,16 @@ def _catch_bad_metadata_file_requests(metadata_output, source, destination):
     real_metadata = os.path.realpath(metadata_output.output_file)
 
     if os.path.isdir(real_metadata):
-        raise BadUserArgumentError('Metadata output cannot be a directory')
+        raise BadUserArgumentError("Metadata output cannot be a directory")
 
     if real_metadata == real_source or real_metadata == real_destination:
-        raise BadUserArgumentError('Metadata output file cannot be the input or output')
+        raise BadUserArgumentError("Metadata output file cannot be the input or output")
 
     if os.path.isdir(real_destination) and real_metadata.startswith(real_destination):
-        raise BadUserArgumentError('Metadata output file cannot be in the output directory')
+        raise BadUserArgumentError("Metadata output file cannot be in the output directory")
 
     if os.path.isdir(real_source) and real_metadata.startswith(real_source):
-        raise BadUserArgumentError('Metadata output file cannot be in the input directory')
+        raise BadUserArgumentError("Metadata output file cannot be in the input directory")
 
 
 def process_cli_request(stream_args, parsed_args):
@@ -156,9 +157,7 @@ def process_cli_request(stream_args, parsed_args):
     """
     _catch_bad_destination_requests(parsed_args.output)
     _catch_bad_metadata_file_requests(
-        metadata_output=parsed_args.metadata_output,
-        source=parsed_args.input,
-        destination=parsed_args.output
+        metadata_output=parsed_args.metadata_output, source=parsed_args.input, destination=parsed_args.output
     )
     _catch_bad_stdin_stdout_requests(parsed_args.input, parsed_args.output)
 
@@ -169,15 +168,13 @@ def process_cli_request(stream_args, parsed_args):
         decode_input=parsed_args.decode,
         encode_output=parsed_args.encode,
         required_encryption_context=parsed_args.encryption_context,
-        required_encryption_context_keys=parsed_args.required_encryption_context_keys
+        required_encryption_context_keys=parsed_args.required_encryption_context_keys,
     )
 
-    if parsed_args.input == '-':
+    if parsed_args.input == "-":
         # read from stdin
         handler.process_single_operation(
-            stream_args=stream_args,
-            source=parsed_args.input,
-            destination=parsed_args.output
+            stream_args=stream_args, source=parsed_args.input, destination=parsed_args.output
         )
         return
 
@@ -189,14 +186,11 @@ def process_cli_request(stream_args, parsed_args):
 
         if os.path.isdir(_source):
             if not parsed_args.recursive:
-                _LOGGER.warning('Skipping %s because it is a directory and -r/-R/--recursive is not set', _source)
+                _LOGGER.warning("Skipping %s because it is a directory and -r/-R/--recursive is not set", _source)
                 continue
 
             handler.process_dir(
-                stream_args=stream_args,
-                source=_source,
-                destination=_destination,
-                suffix=parsed_args.suffix
+                stream_args=stream_args, source=_source, destination=_destination, suffix=parsed_args.suffix
             )
 
         elif os.path.isfile(_source):
@@ -205,15 +199,11 @@ def process_cli_request(stream_args, parsed_args):
                 _destination = output_filename(
                     source_filename=_source,
                     destination_dir=_destination,
-                    mode=str(stream_args['mode']),
-                    suffix=parsed_args.suffix
+                    mode=str(stream_args["mode"]),
+                    suffix=parsed_args.suffix,
                 )
             # write to file
-            handler.process_single_file(
-                stream_args=stream_args,
-                source=_source,
-                destination=_destination
-            )
+            handler.process_single_file(stream_args=stream_args, source=_source, destination=_destination)
 
 
 def stream_kwargs_from_args(args, crypto_materials_manager):
@@ -228,20 +218,17 @@ def stream_kwargs_from_args(args, crypto_materials_manager):
     :returns: Translated kwargs object for aws_encryption_sdk.stream
     :rtype: dict
     """
-    stream_args = {
-        'materials_manager': crypto_materials_manager,
-        'mode': args.action
-    }
+    stream_args = {"materials_manager": crypto_materials_manager, "mode": args.action}
     # Look for additional arguments only if encrypting
-    if args.action == 'encrypt':
-        stream_args['encryption_context'] = args.encryption_context
+    if args.action == "encrypt":
+        stream_args["encryption_context"] = args.encryption_context
         if args.algorithm is not None:
-            stream_args['algorithm'] = getattr(aws_encryption_sdk.Algorithm, args.algorithm)
+            stream_args["algorithm"] = getattr(aws_encryption_sdk.Algorithm, args.algorithm)
         if args.frame_length is not None:
-            stream_args['frame_length'] = args.frame_length
+            stream_args["frame_length"] = args.frame_length
 
     if args.max_length is not None:
-        stream_args['max_body_length'] = args.max_length
+        stream_args["max_body_length"] = args.max_length
     return stream_args
 
 
@@ -256,15 +243,14 @@ def cli(raw_args=None):
 
         setup_logger(args.verbosity, args.quiet)
 
-        _LOGGER.debug('Encryption mode: %s', args.action)
-        _LOGGER.debug('Encryption source: %s', args.input)
-        _LOGGER.debug('Encryption destination: %s', args.output)
-        _LOGGER.debug('Master key provider configuration: %s', args.master_keys)
-        _LOGGER.debug('Suffix requested: %s', args.suffix)
+        _LOGGER.debug("Encryption mode: %s", args.action)
+        _LOGGER.debug("Encryption source: %s", args.input)
+        _LOGGER.debug("Encryption destination: %s", args.output)
+        _LOGGER.debug("Master key provider configuration: %s", args.master_keys)
+        _LOGGER.debug("Suffix requested: %s", args.suffix)
 
         crypto_materials_manager = build_crypto_materials_manager_from_args(
-            key_providers_config=args.master_keys,
-            caching_config=args.caching
+            key_providers_config=args.master_keys, caching_config=args.caching
         )
 
         stream_args = stream_kwargs_from_args(args, crypto_materials_manager)
@@ -275,13 +261,14 @@ def cli(raw_args=None):
     except AWSEncryptionSDKCLIError as error:
         return error.args[0]
     except Exception as error:  # pylint: disable=broad-except
-        message = os.linesep.join([
-            'Encountered unexpected error: increase verbosity to see details.',
-            '{cls}({args})'.format(
-                cls=error.__class__.__name__,
-                args=', '.join(['"{}"'.format(arg) for arg in error.args])
-            )
-        ])
+        message = os.linesep.join(
+            [
+                "Encountered unexpected error: increase verbosity to see details.",
+                "{cls}({args})".format(
+                    cls=error.__class__.__name__, args=", ".join(['"{}"'.format(arg) for arg in error.args])
+                ),
+            ]
+        )
         _LOGGER.debug(message)
         # copy.deepcopy can't handle raw exc_info objects, so format it first
         formatted_traceback = traceback.format_exc()

--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -23,8 +23,6 @@ from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager  #
 
 from aws_encryption_sdk_cli.exceptions import AWSEncryptionSDKCLIError, BadUserArgumentError
 from aws_encryption_sdk_cli.internal.arg_parsing import parse_args
-
-# convenience import separated from other imports from this module to avoid over-application of linting override
 from aws_encryption_sdk_cli.internal.identifiers import __version__  # noqa
 from aws_encryption_sdk_cli.internal.io_handling import IOHandler, output_filename
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME, setup_logger

--- a/src/aws_encryption_sdk_cli/internal/arg_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/arg_parsing.py
@@ -30,14 +30,18 @@ from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Any, Dict, List, Optional, Sequence, Tuple, Union  # noqa pylint: disable=unused-import
     from aws_encryption_sdk_cli.internal.mypy_types import (  # noqa pylint: disable=unused-import
-        ARGPARSE_TEXT, CACHING_CONFIG, COLLAPSED_CONFIG,
-        MASTER_KEY_PROVIDER_CONFIG, PARSED_CONFIG, RAW_CONFIG
+        ARGPARSE_TEXT,
+        CACHING_CONFIG,
+        COLLAPSED_CONFIG,
+        MASTER_KEY_PROVIDER_CONFIG,
+        PARSED_CONFIG,
+        RAW_CONFIG,
     )
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-__all__ = ('parse_args',)
+__all__ = ("parse_args",)
 _LOGGER = logging.getLogger(LOGGER_NAME)
 
 
@@ -64,10 +68,10 @@ class CommentIgnoringArgumentParser(argparse.ArgumentParser):
         """
         self.add_argument(
             expected_name[1:],
-            dest='dummy_redirect',
-            action='store_const',
+            dest="dummy_redirect",
+            action="store_const",
             const=expected_name[1:],
-            help=argparse.SUPPRESS
+            help=argparse.SUPPRESS,
         )
         # ArgumentParser subclass confuses mypy
         self.__dummy_arguments.append(expected_name[1:])  # type: ignore
@@ -98,9 +102,9 @@ class CommentIgnoringArgumentParser(argparse.ArgumentParser):
         """
         shlexer = shlex.shlex(six.StringIO(arg_line), posix=True)  # type: ignore #  shlex confuses mypy
         shlexer.whitespace_split = True
-        shlexer.escapedquotes = '\'"'
+        shlexer.escapedquotes = "'\""
         if self.__is_windows:
-            shlexer.escape = '`'
+            shlexer.escape = "`"
         return list(shlexer)  # type: ignore #  shlex confuses mypy
 
     def convert_arg_line_to_args(self, arg_line):
@@ -124,11 +128,11 @@ class UniqueStoreAction(argparse.Action):  # pylint: disable=too-few-public-meth
     """argparse action that requires that arguments cannot be repeated."""
 
     def __call__(
-            self,
-            parser,  # type: argparse.ArgumentParser
-            namespace,  # type: argparse.Namespace
-            values,  # type: Union[ARGPARSE_TEXT, Sequence[Any], None]
-            option_string=None  # type: Optional[ARGPARSE_TEXT]
+        self,
+        parser,  # type: argparse.ArgumentParser
+        namespace,  # type: argparse.Namespace
+        values,  # type: Union[ARGPARSE_TEXT, Sequence[Any], None]
+        option_string=None,  # type: Optional[ARGPARSE_TEXT]
     ):
         # type: (...) -> None
         """Checks to make sure that the destination is empty before writing.
@@ -136,7 +140,7 @@ class UniqueStoreAction(argparse.Action):  # pylint: disable=too-few-public-meth
         :raises parser.error: if destination is already set
         """
         if getattr(namespace, self.dest) is not None:  # type: ignore # typeshed doesn't know about Action.dest yet?
-            parser.error('{} argument may not be specified more than once'.format(option_string))
+            parser.error("{} argument may not be specified more than once".format(option_string))
             return
         setattr(namespace, self.dest, values)  # type: ignore # typeshed doesn't know about Action.dest yet?
 
@@ -148,13 +152,11 @@ def _version_report():
     :rtype: str
     """
     versions = OrderedDict()  # type: Dict[str, str]
-    versions['aws-encryption-sdk-cli'] = __version__
-    versions['aws-encryption-sdk'] = aws_encryption_sdk.__version__
-    return ' '.join([
-        '{target}/{version}'.format(target=target, version=version)
-        for target, version
-        in versions.items()
-    ])
+    versions["aws-encryption-sdk-cli"] = __version__
+    versions["aws-encryption-sdk"] = aws_encryption_sdk.__version__
+    return " ".join(
+        ["{target}/{version}".format(target=target, version=version) for target, version in versions.items()]
+    )
 
 
 def _build_parser():
@@ -165,209 +167,164 @@ def _build_parser():
     :rtype: argparse.ArgumentParser
     """
     parser = CommentIgnoringArgumentParser(
-        description='Encrypt or decrypt data using the AWS Encryption SDK',
-        epilog='For more usage instructions and examples, see: http://aws-encryption-sdk-cli.readthedocs.io/en/latest/',
-        fromfile_prefix_chars='@'
+        description="Encrypt or decrypt data using the AWS Encryption SDK",
+        epilog="For more usage instructions and examples, see: http://aws-encryption-sdk-cli.readthedocs.io/en/latest/",
+        fromfile_prefix_chars="@",
     )
 
     # For each argument added to this group, a dummy redirect argument must
     # be added to the parent parser for each long form option string.
     version_or_action = parser.add_mutually_exclusive_group(required=True)
 
-    version_or_action.add_argument(
-        '--version',
-        action='version',
-        version=_version_report()
-    )
-    parser.add_dummy_redirect_argument('--version')
+    version_or_action.add_argument("--version", action="version", version=_version_report())
+    parser.add_dummy_redirect_argument("--version")
 
     # For each argument added to this group, a dummy redirect argument must
     # be added to the parent parser for each long form option string.
     operating_action = version_or_action.add_mutually_exclusive_group()
     operating_action.add_argument(
-        '-e',
-        '--encrypt',
-        dest='action',
-        action='store_const',
-        const='encrypt',
-        help='Encrypt data'
+        "-e", "--encrypt", dest="action", action="store_const", const="encrypt", help="Encrypt data"
     )
-    parser.add_dummy_redirect_argument('--encrypt')
+    parser.add_dummy_redirect_argument("--encrypt")
     operating_action.add_argument(
-        '-d',
-        '--decrypt',
-        dest='action',
-        action='store_const',
-        const='decrypt',
-        help='Decrypt data'
+        "-d", "--decrypt", dest="action", action="store_const", const="decrypt", help="Decrypt data"
     )
-    parser.add_dummy_redirect_argument('--decrypt')
+    parser.add_dummy_redirect_argument("--decrypt")
 
     # For each argument added to this group, a dummy redirect argument must
     # be added to the parent parser for each long form option string.
     metadata_group = parser.add_mutually_exclusive_group(required=True)
 
     metadata_group.add_argument(
-        '-S',
-        '--suppress-metadata',
-        action='store_const',
+        "-S",
+        "--suppress-metadata",
+        action="store_const",
         const=MetadataWriter(suppress_output=True)(),
-        dest='metadata_output',
-        help='Suppress metadata output.'
+        dest="metadata_output",
+        help="Suppress metadata output.",
     )
-    parser.add_dummy_redirect_argument('--suppress-metadata')
+    parser.add_dummy_redirect_argument("--suppress-metadata")
 
     metadata_group.add_argument(
-        '--metadata-output',
-        type=MetadataWriter(),
-        help='File to which to write metadata records'
+        "--metadata-output", type=MetadataWriter(), help="File to which to write metadata records"
     )
-    parser.add_dummy_redirect_argument('--metadata-output')
+    parser.add_dummy_redirect_argument("--metadata-output")
 
     parser.add_argument(
-        '--overwrite-metadata',
-        action='store_true',
-        help='Force metadata output to overwrite contents of file rather than appending to file'
+        "--overwrite-metadata",
+        action="store_true",
+        help="Force metadata output to overwrite contents of file rather than appending to file",
     )
 
     parser.add_argument(
-        '-m',
-        '--master-keys',
-        nargs='+',
-        action='append',
+        "-m",
+        "--master-keys",
+        nargs="+",
+        action="append",
         required=False,
         help=(
-            'Identifying information for a master key provider and master keys. Each instance must include '
-            'a master key provider identifier and identifiers for one or more master key supplied by that provider. '
-            'ex: '
-            '--master-keys provider=aws-kms key=$AWS_KMS_KEY_ARN'
-        )
+            "Identifying information for a master key provider and master keys. Each instance must include "
+            "a master key provider identifier and identifiers for one or more master key supplied by that provider. "
+            "ex: "
+            "--master-keys provider=aws-kms key=$AWS_KMS_KEY_ARN"
+        ),
     )
 
     parser.add_argument(
-        '--caching',
-        nargs='+',
+        "--caching",
+        nargs="+",
         required=False,
         action=UniqueStoreAction,
         help=(
-            'Configuration options for a caching cryptographic materials manager and local cryptographic materials '
+            "Configuration options for a caching cryptographic materials manager and local cryptographic materials "
             'cache. Must consist of "key=value" pairs. If caching, at least "capacity" and "max_age" must be defined. '
-            'ex: '
-            '--caching capacity=10 max_age=100.0'
-        )
+            "ex: "
+            "--caching capacity=10 max_age=100.0"
+        ),
     )
 
     parser.add_argument(
-        '-i',
-        '--input',
+        "-i",
+        "--input",
         required=True,
         action=UniqueStoreAction,
-        help='Input file or directory for encrypt/decrypt operation, or "-" for stdin.'
+        help='Input file or directory for encrypt/decrypt operation, or "-" for stdin.',
     )
     parser.add_argument(
-        '-o',
-        '--output',
+        "-o",
+        "--output",
         required=True,
         action=UniqueStoreAction,
-        help='Output file or directory for encrypt/decrypt operation, or - for stdout.'
+        help="Output file or directory for encrypt/decrypt operation, or - for stdout.",
     )
 
-    parser.add_argument(
-        '--encode',
-        action='store_true',
-        help='Base64-encode output after processing'
-    )
-    parser.add_argument(
-        '--decode',
-        action='store_true',
-        help='Base64-decode input before processing'
-    )
+    parser.add_argument("--encode", action="store_true", help="Base64-encode output after processing")
+    parser.add_argument("--decode", action="store_true", help="Base64-decode input before processing")
 
     parser.add_argument(
-        '-c',
-        '--encryption-context',
-        nargs='+',
+        "-c",
+        "--encryption-context",
+        nargs="+",
         action=UniqueStoreAction,
         help=(
             'key-value pair encryption context values (encryption only). Must a set of "key=value" pairs. '
-            'ex: '
-            '-c key1=value1 key2=value2'
-        )
+            "ex: "
+            "-c key1=value1 key2=value2"
+        ),
     )
 
     # Note: This is added as an argument for argparse API consistency, but it should not be used directly.
     parser.add_argument(
-        '--required-encryption-context-keys',
-        nargs='+',
-        action=UniqueStoreAction,
-        help=argparse.SUPPRESS
+        "--required-encryption-context-keys", nargs="+", action=UniqueStoreAction, help=argparse.SUPPRESS
     )
 
     parser.add_argument(
-        '--algorithm',
-        action=UniqueStoreAction,
-        help='Algorithm name (encryption only)',
-        choices=ALGORITHM_NAMES
+        "--algorithm", action=UniqueStoreAction, help="Algorithm name (encryption only)", choices=ALGORITHM_NAMES
     )
 
     parser.add_argument(
-        '--frame-length',
-        dest='frame_length',
+        "--frame-length",
+        dest="frame_length",
         type=int,
         action=UniqueStoreAction,
-        help='Frame length in bytes (encryption only)'
+        help="Frame length in bytes (encryption only)",
     )
 
     parser.add_argument(
-        '--max-length',
+        "--max-length",
         type=int,
         action=UniqueStoreAction,
         help=(
-            'Maximum frame length (for framed messages) or content length (for '
-            'non-framed messages) (decryption only)'
-        )
+            "Maximum frame length (for framed messages) or content length (for "
+            "non-framed messages) (decryption only)"
+        ),
     )
 
     parser.add_argument(
-        '--suffix',
-        nargs='?',
-        const='',
+        "--suffix",
+        nargs="?",
+        const="",
         action=UniqueStoreAction,
-        help='Custom suffix to use when target filename is not specified (empty if specified but no value provided)'
+        help="Custom suffix to use when target filename is not specified (empty if specified but no value provided)",
     )
 
     parser.add_argument(
-        '--interactive',
-        action='store_true',
-        help='Force aws-encryption-cli to prompt you for verification before overwriting existing files'
+        "--interactive",
+        action="store_true",
+        help="Force aws-encryption-cli to prompt you for verification before overwriting existing files",
     )
 
-    parser.add_argument(
-        '--no-overwrite',
-        action='store_true',
-        help='Never overwrite existing files'
-    )
+    parser.add_argument("--no-overwrite", action="store_true", help="Never overwrite existing files")
+
+    parser.add_argument("-r", "-R", "--recursive", action="store_true", help="Allow operation on directories as input")
 
     parser.add_argument(
-        '-r',
-        '-R',
-        '--recursive',
-        action='store_true',
-        help='Allow operation on directories as input'
+        "-v",
+        dest="verbosity",
+        action="count",
+        help="Enables logging and sets detail level. Multiple -v options increases verbosity (max: 4).",
     )
-
-    parser.add_argument(
-        '-v',
-        dest='verbosity',
-        action='count',
-        help='Enables logging and sets detail level. Multiple -v options increases verbosity (max: 4).'
-    )
-    parser.add_argument(
-        '-q',
-        '--quiet',
-        action='store_true',
-        help='Suppresses most warning and diagnostic messages'
-    )
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppresses most warning and diagnostic messages")
     return parser
 
 
@@ -383,14 +340,14 @@ def _parse_kwargs(args):
     value_error_message = 'Argument parameter must follow the format "key=value"'
     kwargs = defaultdict(list)  # type: Dict[str, List[str]]
     for arg in args:
-        _LOGGER.debug('Attempting to parse argument: %s', arg)
+        _LOGGER.debug("Attempting to parse argument: %s", arg)
         try:
-            key, value = arg.split('=', 1)
+            key, value = arg.split("=", 1)
             if not (key and value):
                 raise ParameterParseError(value_error_message)
             kwargs[key].append(value)
         except ValueError:
-            _LOGGER.debug('Failed to parse argument')
+            _LOGGER.debug("Failed to parse argument")
             raise ParameterParseError(value_error_message)
     return dict(kwargs)
 
@@ -425,9 +382,7 @@ def _parse_and_collapse_config(raw_config):
 
 
 def _process_encryption_context(
-        action,
-        raw_encryption_context,
-        raw_required_encryption_context_keys
+    action, raw_encryption_context, raw_required_encryption_context_keys
 ):  # pylint: disable=invalid-name
     # type: (str, RAW_CONFIG, RAW_CONFIG) -> Tuple[Dict[str, str], List[str]]
     """Applies processing to prepare the encryption context and required encryption context keys.
@@ -445,12 +400,12 @@ def _process_encryption_context(
     if raw_encryption_context is None:
         return {}, required_keys
 
-    if action == 'encrypt':
+    if action == "encrypt":
         return _parse_and_collapse_config(raw_encryption_context), required_keys
 
     initial_encryption_context = []  # type: List[str]
     for param in raw_encryption_context:
-        if '=' in param:
+        if "=" in param:
             initial_encryption_context.append(param)
         else:
             required_keys.append(param)
@@ -468,15 +423,10 @@ def _process_caching_config(raw_caching_config):
     :raises ParameterParseError: if invalid parameter name is found
     :raises ParameterParseError: if either capacity or max_age are not defined
     """
-    _cast_types = {
-        'capacity': int,
-        'max_messages_encrypted': int,
-        'max_bytes_encrypted': int,
-        'max_age': float
-    }
+    _cast_types = {"capacity": int, "max_messages_encrypted": int, "max_bytes_encrypted": int, "max_age": float}
     parsed_config = _parse_and_collapse_config(raw_caching_config)
 
-    if 'capacity' not in parsed_config or 'max_age' not in parsed_config:
+    if "capacity" not in parsed_config or "max_age" not in parsed_config:
         raise ParameterParseError('If enabling caching, both "capacity" and "max_age" are required')
 
     caching_config = {}  # type: Dict[str, Union[str, int, float]]
@@ -500,39 +450,37 @@ def _process_master_key_provider_configs(raw_keys, action):
     :raises ParameterParseError: if no key values are provided
     """
     if raw_keys is None:
-        if action == 'decrypt':
+        if action == "decrypt":
             # We allow not defining any master key provider configuration if decrypting with aws-kms.
             _LOGGER.debug(
-                'No master key provider config provided on decrypt request. Using aws-kms with no master keys.'
+                "No master key provider config provided on decrypt request. Using aws-kms with no master keys."
             )
-            return [{'provider': DEFAULT_MASTER_KEY_PROVIDER, 'key': []}]
-        raise ParameterParseError('No master key provider configuration found.')
+            return [{"provider": DEFAULT_MASTER_KEY_PROVIDER, "key": []}]
+        raise ParameterParseError("No master key provider configuration found.")
 
     processed_configs = []  # type: List[MASTER_KEY_PROVIDER_CONFIG]
     for raw_config in raw_keys:
         parsed_args = {}  # type: Dict[str, Union[str, List[str]]]
         parsed_args.update(_parse_kwargs(raw_config))
 
-        provider = parsed_args.get('provider', [DEFAULT_MASTER_KEY_PROVIDER])  # If no provider is defined, use aws-kms
+        provider = parsed_args.get("provider", [DEFAULT_MASTER_KEY_PROVIDER])  # If no provider is defined, use aws-kms
         if len(provider) != 1:
             raise ParameterParseError(
                 'Exactly one "provider" must be provided for each master key provider configuration. '
-                '{} provided'.format(len(provider))
+                "{} provided".format(len(provider))
             )
-        parsed_args['provider'] = provider[0]
+        parsed_args["provider"] = provider[0]
 
-        aws_kms_on_decrypt = parsed_args['provider'] in ('aws-kms', DEFAULT_MASTER_KEY_PROVIDER) and action == 'decrypt'
+        aws_kms_on_decrypt = parsed_args["provider"] in ("aws-kms", DEFAULT_MASTER_KEY_PROVIDER) and action == "decrypt"
 
         if aws_kms_on_decrypt:
-            if 'key' in parsed_args:
+            if "key" in parsed_args:
                 raise ParameterParseError(
-                    'Exact master keys cannot be specified for aws-kms master key provider on decrypt.'
+                    "Exact master keys cannot be specified for aws-kms master key provider on decrypt."
                 )
-            parsed_args['key'] = []
-        elif 'key' not in parsed_args:
-            raise ParameterParseError(
-                'At least one "key" must be provided for each master key provider configuration'
-            )
+            parsed_args["key"] = []
+        elif "key" not in parsed_args:
+            raise ParameterParseError('At least one "key" must be provided for each master key provider configuration')
         processed_configs.append(parsed_args)
     return processed_configs
 
@@ -550,12 +498,12 @@ def parse_args(raw_args=None):
 
     try:
         if parsed_args.dummy_redirect is not None:
-            raise ParameterParseError('Found invalid argument "{actual}". Did you mean "-{actual}"?'.format(
-                actual=parsed_args.dummy_redirect
-            ))
+            raise ParameterParseError(
+                'Found invalid argument "{actual}". Did you mean "-{actual}"?'.format(actual=parsed_args.dummy_redirect)
+            )
 
         if parsed_args.required_encryption_context_keys is not None:
-            raise ParameterParseError('--required-encryption-context-keys cannot be manually provided.')
+            raise ParameterParseError("--required-encryption-context-keys cannot be manually provided.")
 
         if parsed_args.overwrite_metadata:
             parsed_args.metadata_output.force_overwrite()
@@ -565,7 +513,7 @@ def parse_args(raw_args=None):
         parsed_args.encryption_context, parsed_args.required_encryption_context_keys = _process_encryption_context(
             action=parsed_args.action,
             raw_encryption_context=parsed_args.encryption_context,
-            raw_required_encryption_context_keys=parsed_args.required_encryption_context_keys
+            raw_required_encryption_context_keys=parsed_args.required_encryption_context_keys,
         )
 
         if parsed_args.caching is not None:

--- a/src/aws_encryption_sdk_cli/internal/arg_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/arg_parsing.py
@@ -12,18 +12,18 @@
 # language governing permissions and limitations under the License.
 """Helper functions for parsing and processing input arguments."""
 import argparse
-from collections import defaultdict, OrderedDict
 import copy
 import logging
 import os
 import platform
 import shlex
+from collections import OrderedDict, defaultdict
 
 import aws_encryption_sdk
 import six
 
 from aws_encryption_sdk_cli.exceptions import ParameterParseError
-from aws_encryption_sdk_cli.internal.identifiers import __version__, ALGORITHM_NAMES, DEFAULT_MASTER_KEY_PROVIDER
+from aws_encryption_sdk_cli.internal.identifiers import ALGORITHM_NAMES, DEFAULT_MASTER_KEY_PROVIDER, __version__
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
 

--- a/src/aws_encryption_sdk_cli/internal/encoding.py
+++ b/src/aws_encryption_sdk_cli/internal/encoding.py
@@ -29,7 +29,7 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-__all__ = ('Base64IO',)
+__all__ = ("Base64IO",)
 _LOGGER = logging.getLogger(LOGGER_NAME)
 
 
@@ -62,14 +62,14 @@ class Base64IO(io.IOBase):
 
         :raises TypeError: if ``wrapped`` does not have attributes needed to determine the stream's state
         """
-        required_attrs = ('read', 'write', 'close', 'closed', 'flush')
+        required_attrs = ("read", "write", "close", "closed", "flush")
         if not all(hasattr(wrapped, attr) for attr in required_attrs):
-            raise TypeError('Base64IO wrapped object must have attributes: {}'.format(repr(sorted(required_attrs))))
+            raise TypeError("Base64IO wrapped object must have attributes: {}".format(repr(sorted(required_attrs))))
         super(Base64IO, self).__init__()
         self.__wrapped = wrapped
         self.__close_wrapped_on_close = close_wrapped_on_close
-        self.__read_buffer = b''
-        self.__write_buffer = b''
+        self.__read_buffer = b""
+        self.__write_buffer = b""
 
     def __enter__(self):
         # type: () -> Base64IO
@@ -92,7 +92,7 @@ class Base64IO(io.IOBase):
         """
         if self.__write_buffer:
             self.__wrapped.write(base64.b64encode(self.__write_buffer))
-            self.__write_buffer = b''
+            self.__write_buffer = b""
         self.closed = True
         if self.__close_wrapped_on_close:
             self.__wrapped.close()
@@ -128,7 +128,7 @@ class Base64IO(io.IOBase):
 
         :rtype: bool
         """
-        return self._passthrough_interactive_check('writable', 'w')
+        return self._passthrough_interactive_check("writable", "w")
 
     def readable(self):
         # type: () -> bool
@@ -138,7 +138,7 @@ class Base64IO(io.IOBase):
 
         :rtype: bool
         """
-        return self._passthrough_interactive_check('readable', 'r')
+        return self._passthrough_interactive_check("readable", "r")
 
     def flush(self):
         # type: () -> None
@@ -161,14 +161,14 @@ class Base64IO(io.IOBase):
         :raises IOError: if underlying stream is not writable
         """
         if self.closed:
-            raise ValueError('I/O operation on closed file.')
+            raise ValueError("I/O operation on closed file.")
 
         if not self.writable():
-            raise IOError('Stream is not writable')
+            raise IOError("Stream is not writable")
 
         # Load any stashed bytes and clear the buffer
         _bytes_to_write = self.__write_buffer + b
-        self.__write_buffer = b''
+        self.__write_buffer = b""
 
         # If an even base64 chunk or finalizing the stream, write through.
         if len(_bytes_to_write) % 3 == 0:
@@ -204,7 +204,7 @@ class Base64IO(io.IOBase):
             return data
 
         _data_buffer = io.BytesIO()
-        _data_buffer.write(b''.join(data.split()))
+        _data_buffer.write(b"".join(data.split()))
         _remaining_bytes_to_read = total_bytes_to_read - _data_buffer.tell()
 
         while _remaining_bytes_to_read > 0:
@@ -213,7 +213,7 @@ class Base64IO(io.IOBase):
                 # No more data to read from wrapped stream.
                 break
 
-            _data_buffer.write(b''.join(_raw_additional_data.split()))
+            _data_buffer.write(b"".join(_raw_additional_data.split()))
             _remaining_bytes_to_read = total_bytes_to_read - _data_buffer.tell()
         return _data_buffer.getvalue()
 
@@ -227,10 +227,10 @@ class Base64IO(io.IOBase):
         :rtype: bytes
         """
         if self.closed:
-            raise ValueError('I/O operation on closed file.')
+            raise ValueError("I/O operation on closed file.")
 
         if not self.readable():
-            raise IOError('Stream is not readable')
+            raise IOError("Stream is not readable")
 
         if b is not None and b < 0:
             b = None
@@ -238,7 +238,7 @@ class Base64IO(io.IOBase):
         if b is not None:
             # Calculate number of encoded bytes that must be read to get b raw bytes.
             _bytes_to_read = int((b - len(self.__read_buffer)) * 4 / 3)
-            _bytes_to_read += (4 - _bytes_to_read % 4)
+            _bytes_to_read += 4 - _bytes_to_read % 4
 
         # Read encoded bytes from wrapped stream.
         data = self.__wrapped.read(_bytes_to_read)

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -23,29 +23,26 @@ except ImportError:  # pragma: no cover
 
 
 __all__ = (
-    'OUTPUT_SUFFIX',
-    'ALGORITHM_NAMES',
-    'MASTER_KEY_PROVIDERS_ENTRY_POINT',
-    'PLUGIN_NAMESPACE_DIVIDER',
-    'USER_AGENT_SUFFIX',
-    'DEFAULT_MASTER_KEY_PROVIDER',
-    'OperationResult'
+    "OUTPUT_SUFFIX",
+    "ALGORITHM_NAMES",
+    "MASTER_KEY_PROVIDERS_ENTRY_POINT",
+    "PLUGIN_NAMESPACE_DIVIDER",
+    "USER_AGENT_SUFFIX",
+    "DEFAULT_MASTER_KEY_PROVIDER",
+    "OperationResult",
 )
-__version__ = '1.1.4'  # type: str
+__version__ = "1.1.4"  # type: str
 
 #: Suffix added to output files if specific output filename is not specified.
-OUTPUT_SUFFIX = {
-    'encrypt': '.encrypted',
-    'decrypt': '.decrypted'
-}  # type: Dict[str, str]
+OUTPUT_SUFFIX = {"encrypt": ".encrypted", "decrypt": ".decrypted"}  # type: Dict[str, str]
 
-ALGORITHM_NAMES = set([
-    alg for alg in dir(aws_encryption_sdk.Algorithm) if not alg.startswith('_')
-])  # type: Set[aws_encryption_sdk.Algorithm]
-MASTER_KEY_PROVIDERS_ENTRY_POINT = 'aws_encryption_sdk_cli.master_key_providers'
-PLUGIN_NAMESPACE_DIVIDER = '::'
-USER_AGENT_SUFFIX = 'AwsEncryptionSdkCli/{}'.format(__version__)
-DEFAULT_MASTER_KEY_PROVIDER = 'aws-encryption-sdk-cli' + PLUGIN_NAMESPACE_DIVIDER + 'aws-kms'
+ALGORITHM_NAMES = set(
+    [alg for alg in dir(aws_encryption_sdk.Algorithm) if not alg.startswith("_")]
+)  # type: Set[aws_encryption_sdk.Algorithm]
+MASTER_KEY_PROVIDERS_ENTRY_POINT = "aws_encryption_sdk_cli.master_key_providers"
+PLUGIN_NAMESPACE_DIVIDER = "::"
+USER_AGENT_SUFFIX = "AwsEncryptionSdkCli/{}".format(__version__)
+DEFAULT_MASTER_KEY_PROVIDER = "aws-encryption-sdk-cli" + PLUGIN_NAMESPACE_DIVIDER + "aws-kms"
 
 
 class OperationResult(Enum):

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -13,13 +13,14 @@
 """Static identifier values for the AWS Encryption SDK CLI."""
 from enum import Enum
 
+import aws_encryption_sdk
+
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Dict, Set  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-import aws_encryption_sdk
 
 __all__ = (
     'OUTPUT_SUFFIX',

--- a/src/aws_encryption_sdk_cli/internal/io_handling.py
+++ b/src/aws_encryption_sdk_cli/internal/io_handling.py
@@ -23,10 +23,9 @@ import aws_encryption_sdk
 import six
 
 from aws_encryption_sdk_cli.internal.encoding import Base64IO
-from aws_encryption_sdk_cli.internal.identifiers import OperationResult, OUTPUT_SUFFIX
+from aws_encryption_sdk_cli.internal.identifiers import OUTPUT_SUFFIX, OperationResult
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
-from aws_encryption_sdk_cli.internal.metadata import json_ready_header, json_ready_header_auth
-from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
+from aws_encryption_sdk_cli.internal.metadata import MetadataWriter, json_ready_header, json_ready_header_auth
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import cast, Dict, IO, List, Type, Union  # noqa pylint: disable=unused-import

--- a/src/aws_encryption_sdk_cli/internal/io_handling.py
+++ b/src/aws_encryption_sdk_cli/internal/io_handling.py
@@ -34,7 +34,7 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-__all__ = ('IOHandler', 'output_filename')
+__all__ = ("IOHandler", "output_filename")
 _LOGGER = logging.getLogger(LOGGER_NAME)
 
 
@@ -79,7 +79,7 @@ def _ensure_dir_exists(filename):
     dest_final_dir = filename.rsplit(os.sep, 1)[0]
     if dest_final_dir == filename:
         # File is in current directory
-        _LOGGER.debug('Target dir is current dir')
+        _LOGGER.debug("Target dir is current dir")
         return
     try:
         os.makedirs(dest_final_dir)
@@ -87,7 +87,7 @@ def _ensure_dir_exists(filename):
         # os.makedirs(... exist_ok=True) does not work in 2.7
         pass
     else:
-        _LOGGER.info('Created directory: %s', dest_final_dir)
+        _LOGGER.info("Created directory: %s", dest_final_dir)
 
 
 def _encoder(stream, should_base64):
@@ -122,7 +122,7 @@ def output_filename(source_filename, destination_dir, mode, suffix):
     else:
         _LOGGER.debug('Using custom suffix "%s" to create output file', suffix)
     filename = source_filename.rsplit(os.sep, 1)[-1]
-    _LOGGER.debug('Duplicating filename %s into %s', filename, destination_dir)
+    _LOGGER.debug("Duplicating filename %s into %s", filename, destination_dir)
     return os.path.join(destination_dir, filename) + suffix
 
 
@@ -134,7 +134,8 @@ def _output_dir(source_root, destination_root, source_dir):
     :param str destination_root: Root of destination directory
     :param str source_dir: Actual directory of source file (child of source_root)
     """
-    suffix = source_dir[len(source_root):].lstrip(os.path.sep)
+    root_len = len(source_root)
+    suffix = source_dir[root_len:].lstrip(os.path.sep)
     return os.path.join(destination_root, suffix)
 
 
@@ -159,17 +160,19 @@ class IOHandler(object):
     decode_input = attr.ib(validator=attr.validators.instance_of(bool))
     encode_output = attr.ib(validator=attr.validators.instance_of(bool))
     required_encryption_context = attr.ib(validator=attr.validators.instance_of(dict))
-    required_encryption_context_keys = attr.ib(validator=attr.validators.instance_of(list))  # noqa pylint: disable=invalid-name
+    required_encryption_context_keys = attr.ib(
+        validator=attr.validators.instance_of(list)
+    )  # noqa pylint: disable=invalid-name
 
     def __init__(
-            self,
-            metadata_writer,  # type: MetadataWriter
-            interactive,  # type: bool
-            no_overwrite,  # type: bool
-            decode_input,  # type: bool
-            encode_output,  # type: bool
-            required_encryption_context,  # type: Dict[str, str]
-            required_encryption_context_keys  # type: List[str]
+        self,
+        metadata_writer,  # type: MetadataWriter
+        interactive,  # type: bool
+        no_overwrite,  # type: bool
+        decode_input,  # type: bool
+        encode_output,  # type: bool
+        required_encryption_context,  # type: Dict[str, str]
+        required_encryption_context_keys,  # type: List[str]
     ):
         # type: (...) -> None
         """Workaround pending resolution of attrs/mypy interaction.
@@ -197,13 +200,15 @@ class IOHandler(object):
         :returns: OperationResult stating whether the file was written
         :rtype: aws_encryption_sdk_cli.internal.identifiers.OperationResult
         """
-        with _encoder(source, self.decode_input) as _source, _encoder(destination_writer, self.encode_output) as _destination:  # noqa pylint: disable=line-too-long
+        with _encoder(source, self.decode_input) as _source, _encoder(
+            destination_writer, self.encode_output
+        ) as _destination:  # noqa pylint: disable=line-too-long
             with aws_encryption_sdk.stream(source=_source, **stream_args) as handler, self.metadata_writer as metadata:
                 metadata_kwargs = dict(
-                    mode=stream_args['mode'],
+                    mode=stream_args["mode"],
                     input=source.name,
                     output=destination_writer.name,
-                    header=json_ready_header(handler.header)
+                    header=json_ready_header(handler.header),
                 )
                 try:
                     header_auth = handler.header_auth
@@ -211,22 +216,24 @@ class IOHandler(object):
                     # EncryptStream doesn't expose the header auth at this time
                     pass
                 else:
-                    metadata_kwargs['header_auth'] = json_ready_header_auth(header_auth)
+                    metadata_kwargs["header_auth"] = json_ready_header_auth(header_auth)
 
-                if stream_args['mode'] == 'decrypt':
+                if stream_args["mode"] == "decrypt":
                     discovered_ec = handler.header.encryption_context
                     missing_keys = set(self.required_encryption_context_keys).difference(set(discovered_ec.keys()))
                     missing_pairs = set(self.required_encryption_context.items()).difference(set(discovered_ec.items()))
                     if missing_keys or missing_pairs:
                         _LOGGER.warning(
-                            'Skipping decrypt because discovered encryption context did not match required elements.'
+                            "Skipping decrypt because discovered encryption context did not match required elements."
                         )
-                        metadata_kwargs.update(dict(
-                            skipped=True,
-                            reason='Missing encryption context key or value',
-                            missing_encryption_context_keys=list(missing_keys),
-                            missing_encryption_context_pairs=list(missing_pairs)
-                        ))
+                        metadata_kwargs.update(
+                            dict(
+                                skipped=True,
+                                reason="Missing encryption context key or value",
+                                missing_encryption_context_keys=list(missing_keys),
+                                missing_encryption_context_pairs=list(missing_pairs),
+                            )
+                        )
                         metadata.write_metadata(**metadata_kwargs)
                         return OperationResult.FAILED_VALIDATION
 
@@ -247,22 +254,20 @@ class IOHandler(object):
         :returns: OperationResult stating whether the file was written
         :rtype: aws_encryption_sdk_cli.internal.identifiers.OperationResult
         """
-        if destination == '-':
+        if destination == "-":
             destination_writer = _stdout()
         else:
             if not self._should_write_file(destination):
                 return OperationResult.SKIPPED
             _ensure_dir_exists(destination)
-            destination_writer = open(os.path.abspath(destination), 'wb')
+            destination_writer = open(os.path.abspath(destination), "wb")
 
-        if source == '-':
+        if source == "-":
             source = _stdin()
 
         try:
             return self._single_io_write(
-                stream_args=stream_args,
-                source=cast(IO, source),
-                destination_writer=destination_writer
+                stream_args=stream_args, source=cast(IO, source), destination_writer=destination_writer
             )
         finally:
             destination_writer.close()
@@ -289,17 +294,17 @@ class IOHandler(object):
                 'Overwrite existing output file "{}" with new contents? [y/N]:'.format(filepath)
             )
             try:
-                if decision.lower()[0] == 'y':
-                    _LOGGER.warning('Overwriting existing output file based on interactive user decision: %s', filepath)
+                if decision.lower()[0] == "y":
+                    _LOGGER.warning("Overwriting existing output file based on interactive user decision: %s", filepath)
                     return True
                 return False
             except IndexError:
                 # No input is interpreted as 'do not overwrite'
-                _LOGGER.warning('Skipping existing output file based on interactive user decision: %s', filepath)
+                _LOGGER.warning("Skipping existing output file based on interactive user decision: %s", filepath)
                 return False
 
         # If we get to this point, the file exists and we should overwrite it
-        _LOGGER.warning('Overwriting existing output file because no action was specified otherwise: %s', filepath)
+        _LOGGER.warning("Overwriting existing output file because no action was specified otherwise: %s", filepath)
         return True
 
     def process_single_file(self, stream_args, source, destination):
@@ -312,10 +317,10 @@ class IOHandler(object):
         """
         if os.path.realpath(source) == os.path.realpath(destination):
             # File source, directory destination, empty suffix:
-            _LOGGER.warning('Skipping because the source (%s) and destination (%s) are the same', source, destination)
+            _LOGGER.warning("Skipping because the source (%s) and destination (%s) are the same", source, destination)
             return
 
-        _LOGGER.info('%sing file %s to %s', stream_args['mode'], source, destination)
+        _LOGGER.info("%sing file %s to %s", stream_args["mode"], source, destination)
 
         _stream_args = copy.copy(stream_args)
         # Because we can actually know size for files and Base64IO does not support seeking,
@@ -323,23 +328,21 @@ class IOHandler(object):
         # Base64-decoding a source file.
         source_file_size = os.path.getsize(source)
         if self.decode_input and not self.encode_output:
-            _stream_args['source_length'] = int(source_file_size * (3 / 4))
+            _stream_args["source_length"] = int(source_file_size * (3 / 4))
         else:
-            _stream_args['source_length'] = source_file_size
+            _stream_args["source_length"] = source_file_size
 
         try:
-            with open(os.path.abspath(source), 'rb') as source_reader:
+            with open(os.path.abspath(source), "rb") as source_reader:
                 operation_result = self.process_single_operation(
-                    stream_args=_stream_args,
-                    source=source_reader,
-                    destination=destination
+                    stream_args=_stream_args, source=source_reader, destination=destination
                 )
         except Exception:  # pylint: disable=broad-except
             operation_result = OperationResult.FAILED
             raise
         finally:
-            if operation_result.needs_cleanup and destination != '-':
-                _LOGGER.warning('Operation failed: deleting output file: %s', destination)
+            if operation_result.needs_cleanup and destination != "-":
+                _LOGGER.warning("Operation failed: deleting output file: %s", destination)
                 try:
                     os.remove(destination)
                 except OSError:
@@ -355,23 +358,17 @@ class IOHandler(object):
         :param str destination: Full file path to destination directory root
         :param str suffix: Suffix to append to output filename
         """
-        _LOGGER.debug('%sing directory %s to %s', stream_args['mode'], source, destination)
+        _LOGGER.debug("%sing directory %s to %s", stream_args["mode"], source, destination)
         for base_dir, _dirs, files in os.walk(source):
             for filename in files:
                 source_filename = os.path.join(base_dir, filename)
-                destination_dir = _output_dir(
-                    source_root=source,
-                    destination_root=destination,
-                    source_dir=base_dir
-                )
+                destination_dir = _output_dir(source_root=source, destination_root=destination, source_dir=base_dir)
                 destination_filename = output_filename(
                     source_filename=source_filename,
                     destination_dir=destination_dir,
-                    mode=str(stream_args['mode']),
-                    suffix=suffix
+                    mode=str(stream_args["mode"]),
+                    suffix=suffix,
                 )
                 self.process_single_file(
-                    stream_args=stream_args,
-                    source=source_filename,
-                    destination=destination_filename
+                    stream_args=stream_args, source=source_filename, destination=destination_filename
                 )

--- a/src/aws_encryption_sdk_cli/internal/logging_utils.py
+++ b/src/aws_encryption_sdk_cli/internal/logging_utils.py
@@ -22,16 +22,12 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-__all__ = ('setup_logger', 'LOGGER_NAME')
-LOGGING_LEVELS = {
-    0: logging.CRITICAL,
-    1: logging.INFO,
-    2: logging.DEBUG
-}  # type: Dict[int, int]
-LOGGER_NAME = 'aws_encryption_sdk_cli'  # type: str
-FORMAT_STRING = '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'  # type: str
+__all__ = ("setup_logger", "LOGGER_NAME")
+LOGGING_LEVELS = {0: logging.CRITICAL, 1: logging.INFO, 2: logging.DEBUG}  # type: Dict[int, int]
+LOGGER_NAME = "aws_encryption_sdk_cli"  # type: str
+FORMAT_STRING = "%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s"  # type: str
 MAX_LOGGING_LEVEL = 2  # type: int
-_REDACTED = '<**-redacted-**>'  # type: str
+_REDACTED = "<**-redacted-**>"  # type: str
 
 
 class _KMSKeyRedactingFormatter(logging.Formatter):
@@ -46,7 +42,7 @@ class _KMSKeyRedactingFormatter(logging.Formatter):
         :rtype: str
         """
         if isinstance(value, bytes):
-            return codecs.decode(value, 'utf-8')
+            return codecs.decode(value, "utf-8")
         return value
 
     def __is_kms_encrypt_request(self, record):  # pylint: disable=no-self-use
@@ -58,11 +54,13 @@ class _KMSKeyRedactingFormatter(logging.Formatter):
         :rtype: bool
         """
         try:
-            return all((
-                record.name == 'botocore.endpoint',
-                record.msg.startswith('Making request'),
-                cast(tuple, record.args)[-1]['headers']['X-Amz-Target'] == 'TrentService.Encrypt'
-            ))
+            return all(
+                (
+                    record.name == "botocore.endpoint",
+                    record.msg.startswith("Making request"),
+                    cast(tuple, record.args)[-1]["headers"]["X-Amz-Target"] == "TrentService.Encrypt",
+                )
+            )
         except Exception:  # pylint: disable=broad-except
             return False
 
@@ -74,9 +72,9 @@ class _KMSKeyRedactingFormatter(logging.Formatter):
         :type record: logging.LogRecord
         """
         try:
-            parsed_body = json.loads(self.__to_str(cast(tuple, record.args)[-1]['body']))
-            parsed_body['Plaintext'] = _REDACTED
-            cast(tuple, record.args)[-1]['body'] = json.dumps(parsed_body, sort_keys=True)
+            parsed_body = json.loads(self.__to_str(cast(tuple, record.args)[-1]["body"]))
+            parsed_body["Plaintext"] = _REDACTED
+            cast(tuple, record.args)[-1]["body"] = json.dumps(parsed_body, sort_keys=True)
         except Exception:  # pylint: disable=broad-except
             return
 
@@ -89,12 +87,14 @@ class _KMSKeyRedactingFormatter(logging.Formatter):
         :rtype: bool
         """
         try:
-            return all((
-                record.name == 'botocore.parsers',
-                record.msg.startswith('Response body:'),
-                b'KeyId' in cast(tuple, record.args)[0],
-                b'Plaintext' in cast(tuple, record.args)[0]
-            ))
+            return all(
+                (
+                    record.name == "botocore.parsers",
+                    record.msg.startswith("Response body:"),
+                    b"KeyId" in cast(tuple, record.args)[0],
+                    b"Plaintext" in cast(tuple, record.args)[0],
+                )
+            )
         except Exception:  # pylint: disable=broad-except
             return False
 
@@ -107,7 +107,7 @@ class _KMSKeyRedactingFormatter(logging.Formatter):
         """
         try:
             parsed_body = json.loads(self.__to_str(cast(tuple, record.args)[0]))
-            parsed_body['Plaintext'] = _REDACTED
+            parsed_body["Plaintext"] = _REDACTED
             new_args = (json.dumps(parsed_body, sort_keys=True),) + cast(tuple, record.args)[1:]
             record.args = new_args
         except Exception:  # pylint: disable=broad-except

--- a/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
@@ -26,13 +26,14 @@ from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Callable, DefaultDict, Dict, List, Union  # noqa pylint: disable=unused-import
     from aws_encryption_sdk_cli.internal.mypy_types import (  # noqa pylint: disable=unused-import
-        CACHING_CONFIG, RAW_MASTER_KEY_PROVIDER_CONFIG
+        CACHING_CONFIG,
+        RAW_MASTER_KEY_PROVIDER_CONFIG,
     )
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-__all__ = ('build_crypto_materials_manager_from_args',)
+__all__ = ("build_crypto_materials_manager_from_args",)
 _LOGGER = logging.getLogger(LOGGER_NAME)
 _ENTRY_POINTS = defaultdict(dict)  # type: DefaultDict[str, Dict[str, pkg_resources.EntryPoint]]
 
@@ -40,23 +41,26 @@ _ENTRY_POINTS = defaultdict(dict)  # type: DefaultDict[str, Dict[str, pkg_resour
 def _discover_entry_points():
     # type: () -> None
     """Discover all registered entry points."""
-    _LOGGER.debug('Discovering master key provider plugins')
+    _LOGGER.debug("Discovering master key provider plugins")
 
     for entry_point in pkg_resources.iter_entry_points(MASTER_KEY_PROVIDERS_ENTRY_POINT):
         _LOGGER.info('Collecting plugin "%s" registered by "%s"', entry_point.name, entry_point.dist)
-        _LOGGER.debug('Plugin details: %s', dict(
-            name=entry_point.name,
-            module_name=entry_point.module_name,
-            attrs=entry_point.attrs,
-            extras=entry_point.extras,
-            dist=entry_point.dist
-        ))
+        _LOGGER.debug(
+            "Plugin details: %s",
+            dict(
+                name=entry_point.name,
+                module_name=entry_point.module_name,
+                attrs=entry_point.attrs,
+                extras=entry_point.extras,
+                dist=entry_point.dist,
+            ),
+        )
 
         if PLUGIN_NAMESPACE_DIVIDER in entry_point.name:
             _LOGGER.warning(
                 'Invalid substring "%s" in discovered entry point "%s". It will not be usable.',
                 PLUGIN_NAMESPACE_DIVIDER,
-                entry_point.name
+                entry_point.name,
             )
             continue
 
@@ -87,7 +91,7 @@ def _load_master_key_provider(name):
     if PLUGIN_NAMESPACE_DIVIDER in name:
         package_name, entry_point_name = name.split(PLUGIN_NAMESPACE_DIVIDER, 1)
     else:
-        package_name = ''
+        package_name = ""
         entry_point_name = name
 
     entry_points = _entry_points()[entry_point_name]
@@ -100,8 +104,8 @@ def _load_master_key_provider(name):
             return list(entry_points.values())[0].load()
 
         raise BadUserArgumentError(
-            'Multiple entry points discovered and no package specified. Packages discovered registered by: ({})'.format(
-                ', '.join([str(entry.dist) for entry in entry_points.values()])
+            "Multiple entry points discovered and no package specified. Packages discovered registered by: ({})".format(
+                ", ".join([str(entry.dist) for entry in entry_points.values()])
             )
         )
 
@@ -115,7 +119,7 @@ def _load_master_key_provider(name):
             ).format(
                 requested=name,
                 entry_point=entry_point_name,
-                discovered=', '.join([str(entry.dist) for entry in entry_points.values()])
+                discovered=", ".join([str(entry.dist) for entry in entry_points.values()]),
             )
         )
 
@@ -130,7 +134,7 @@ def _build_master_key_provider(provider, key, **kwargs):
     :returns: Master key provider constructed as defined
     :rtype: aws_encryption_sdk.key_providers.base.MasterKeyProvider
     """
-    _LOGGER.debug('Loading provider: %s', provider)
+    _LOGGER.debug("Loading provider: %s", provider)
 
     provider_callable = _load_master_key_provider(provider)
     key_provider = provider_callable(**kwargs)
@@ -166,13 +170,9 @@ def _parse_master_key_providers_from_args(*key_providers_info):
     key_providers = []
     for provider_info in key_providers_info:
         info = copy.deepcopy(provider_info)
-        provider = str(info.pop('provider'))
-        key_ids = [str(key_id) for key_id in info.pop('key')]
-        key_providers.append(_build_master_key_provider(
-            provider=provider,
-            key=key_ids,
-            **info
-        ))
+        provider = str(info.pop("provider"))
+        key_ids = [str(key_id) for key_id in info.pop("key")]
+        key_providers.append(_build_master_key_provider(provider=provider, key=key_ids, **info))
 
     return _assemble_master_key_providers(*key_providers)  # pylint: disable=no-value-for-parameter
 
@@ -192,9 +192,7 @@ def build_crypto_materials_manager_from_args(key_providers_config, caching_confi
     if caching_config is None:
         return cmm
 
-    cache = aws_encryption_sdk.LocalCryptoMaterialsCache(capacity=caching_config.pop('capacity'))
+    cache = aws_encryption_sdk.LocalCryptoMaterialsCache(capacity=caching_config.pop("capacity"))
     return aws_encryption_sdk.CachingCryptoMaterialsManager(
-        backing_materials_manager=cmm,
-        cache=cache,
-        **caching_config
+        backing_materials_manager=cmm, cache=cache, **caching_config
     )

--- a/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
@@ -11,13 +11,13 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Helper functions for building crypto materials manager and underlying master key provider(s) from arguments."""
-from collections import defaultdict
 import copy
 import logging
+from collections import defaultdict
 
 import aws_encryption_sdk
-from aws_encryption_sdk.key_providers.base import MasterKeyProvider  # noqa pylint: disable=unused-import
 import pkg_resources
+from aws_encryption_sdk.key_providers.base import MasterKeyProvider  # noqa pylint: disable=unused-import
 
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal.identifiers import MASTER_KEY_PROVIDERS_ENTRY_POINT, PLUGIN_NAMESPACE_DIVIDER

--- a/src/aws_encryption_sdk_cli/internal/metadata.py
+++ b/src/aws_encryption_sdk_cli/internal/metadata.py
@@ -13,16 +13,18 @@
 """Utilities for handling operation metadata."""
 import base64
 import codecs
-from enum import Enum
 import json
 import os
 import sys
+from enum import Enum
 from types import TracebackType  # noqa pylint: disable=unused-import
 
 import attr
-from aws_encryption_sdk.structures import MessageHeader  # noqa pylint: disable=unused-import
-from aws_encryption_sdk.internal.structures import MessageHeaderAuthentication  # noqa pylint: disable=unused-import
 import six
+from aws_encryption_sdk.internal.structures import MessageHeaderAuthentication  # noqa pylint: disable=unused-import
+from aws_encryption_sdk.structures import MessageHeader  # noqa pylint: disable=unused-import
+
+from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import Any, Dict, IO, Optional, Text, Union  # noqa pylint: disable=unused-import
@@ -30,7 +32,6 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 
 __all__ = ('MetadataWriter', 'unicode_b64_encode', 'json_ready_header', 'json_ready_header_auth')
 

--- a/src/aws_encryption_sdk_cli/internal/metadata.py
+++ b/src/aws_encryption_sdk_cli/internal/metadata.py
@@ -33,7 +33,7 @@ except ImportError:  # pragma: no cover
     pass
 
 
-__all__ = ('MetadataWriter', 'unicode_b64_encode', 'json_ready_header', 'json_ready_header_auth')
+__all__ = ("MetadataWriter", "unicode_b64_encode", "json_ready_header", "json_ready_header_auth")
 
 
 @attr.s(hash=False, init=False, cmp=True)
@@ -46,8 +46,7 @@ class MetadataWriter(object):
 
     suppress_output = attr.ib(validator=attr.validators.instance_of(bool))
     output_file = attr.ib(
-        validator=attr.validators.optional(attr.validators.instance_of(six.string_types)),
-        default=None
+        validator=attr.validators.optional(attr.validators.instance_of(six.string_types)), default=None
     )
     _output_mode = None  # type: str
     _output_stream = None  # type: IO
@@ -75,16 +74,16 @@ class MetadataWriter(object):
             return self
 
         if self.output_file is None:
-            raise TypeError('output_file cannot be None when suppress_output is False')
+            raise TypeError("output_file cannot be None when suppress_output is False")
 
-        if self.output_file == '-':
-            self._output_mode = 'w'
+        if self.output_file == "-":
+            self._output_mode = "w"
             return self
 
         if not os.path.isdir(os.path.dirname(os.path.realpath(self.output_file))):
-            raise BadUserArgumentError('Parent directory for requested metdata file does not exist.')
+            raise BadUserArgumentError("Parent directory for requested metdata file does not exist.")
 
-        self._output_mode = 'ab'
+        self._output_mode = "ab"
         self.output_file = os.path.abspath(self.output_file)
 
         attr.validate(self)
@@ -94,13 +93,13 @@ class MetadataWriter(object):
     def force_overwrite(self):
         # type: () -> None
         """Force the output to overwrite the target metadata file."""
-        self._output_mode = 'wb'
+        self._output_mode = "wb"
 
     def open(self):
         # type: () -> None
         """Create and open the output stream."""
         if not self.suppress_output:
-            if self.output_file == '-':
+            if self.output_file == "-":
                 self._output_stream = sys.stdout
             else:
                 self._output_stream = open(self.output_file, self._output_mode)
@@ -121,8 +120,8 @@ class MetadataWriter(object):
 
         # Since we re-use each instance of this in a single call, we only want to overwrite
         # the first time if we are overwriting.
-        if self.output_file != '-':
-            self._output_mode = 'ab'
+        if self.output_file != "-":
+            self._output_mode = "ab"
 
     def __exit__(self, exc_type, exc_value, traceback):
         # type: (type, BaseException, TracebackType) -> None
@@ -139,9 +138,9 @@ class MetadataWriter(object):
             return 0  # wrote 0 bytes
 
         metadata_line = json.dumps(metadata, sort_keys=True) + os.linesep
-        metadata_output = ''  # type: Union[str, bytes]
-        if 'b' in self._output_mode:
-            metadata_output = metadata_line.encode('utf-8')
+        metadata_output = ""  # type: Union[str, bytes]
+        if "b" in self._output_mode:
+            metadata_output = metadata_line.encode("utf-8")
         else:
             metadata_output = metadata_line
         return self._output_stream.write(metadata_output)
@@ -155,7 +154,7 @@ def unicode_b64_encode(value):
     :returns: Unicode base64-encoded value
     :rtype: str/unicode
     """
-    return codecs.decode(base64.b64encode(value), 'utf-8')
+    return codecs.decode(base64.b64encode(value), "utf-8")
 
 
 def json_ready_header(header):
@@ -170,24 +169,24 @@ def json_ready_header(header):
     """
     dict_header = attr.asdict(header)
 
-    del dict_header['content_aad_length']
-    dict_header['version'] = str(float(dict_header['version'].value))
-    dict_header['algorithm'] = dict_header['algorithm'].name
+    del dict_header["content_aad_length"]
+    dict_header["version"] = str(float(dict_header["version"].value))
+    dict_header["algorithm"] = dict_header["algorithm"].name
 
     for key, value in dict_header.items():
         if isinstance(value, Enum):
             dict_header[key] = value.value
 
-    dict_header['message_id'] = unicode_b64_encode(dict_header['message_id'])
+    dict_header["message_id"] = unicode_b64_encode(dict_header["message_id"])
 
-    dict_header['encrypted_data_keys'] = sorted(
-        list(dict_header['encrypted_data_keys']),
-        key=lambda x: six.b(x['key_provider']['provider_id']) + x['key_provider']['key_info']
+    dict_header["encrypted_data_keys"] = sorted(
+        list(dict_header["encrypted_data_keys"]),
+        key=lambda x: six.b(x["key_provider"]["provider_id"]) + x["key_provider"]["key_info"],
     )
-    for data_key in dict_header['encrypted_data_keys']:
-        data_key['key_provider']['provider_id'] = unicode_b64_encode(six.b(data_key['key_provider']['provider_id']))
-        data_key['key_provider']['key_info'] = unicode_b64_encode(data_key['key_provider']['key_info'])
-        data_key['encrypted_data_key'] = unicode_b64_encode(data_key['encrypted_data_key'])
+    for data_key in dict_header["encrypted_data_keys"]:
+        data_key["key_provider"]["provider_id"] = unicode_b64_encode(six.b(data_key["key_provider"]["provider_id"]))
+        data_key["key_provider"]["key_info"] = unicode_b64_encode(data_key["key_provider"]["key_info"])
+        data_key["encrypted_data_key"] = unicode_b64_encode(data_key["encrypted_data_key"])
 
     return dict_header
 

--- a/src/aws_encryption_sdk_cli/internal/mypy_types.py
+++ b/src/aws_encryption_sdk_cli/internal/mypy_types.py
@@ -19,15 +19,15 @@ try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager
 
     __all__ = (
-        'STREAM_KWARGS',
-        'CACHING_CONFIG',
-        'RAW_MASTER_KEY_PROVIDER_CONFIG',
-        'MASTER_KEY_PROVIDER_CONFIG',
-        'RAW_CONFIG',
-        'PARSED_CONFIG',
-        'COLLAPSED_CONFIG',
-        'SOURCE',
-        'ARGPARSE_TEXT'
+        "STREAM_KWARGS",
+        "CACHING_CONFIG",
+        "RAW_MASTER_KEY_PROVIDER_CONFIG",
+        "MASTER_KEY_PROVIDER_CONFIG",
+        "RAW_CONFIG",
+        "PARSED_CONFIG",
+        "COLLAPSED_CONFIG",
+        "SOURCE",
+        "ARGPARSE_TEXT",
     )
 
     STREAM_KWARGS = Dict[str, Union[CryptoMaterialsManager, str, Dict[str, str], Algorithm, int]]

--- a/src/aws_encryption_sdk_cli/key_providers.py
+++ b/src/aws_encryption_sdk_cli/key_providers.py
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-__all__ = ('aws_kms_master_key_provider',)
+__all__ = ("aws_kms_master_key_provider",)
 
 
 def aws_kms_master_key_provider(**kwargs):
@@ -40,10 +40,10 @@ def aws_kms_master_key_provider(**kwargs):
     """
     kwargs = copy.deepcopy(kwargs)
     try:
-        profile_names = kwargs.pop('profile')
+        profile_names = kwargs.pop("profile")
         if len(profile_names) != 1:
             raise BadUserArgumentError(
-                'Only one profile may be specified per master key provider configuration. {} provided.'.format(
+                "Only one profile may be specified per master key provider configuration. {} provided.".format(
                     len(profile_names)
                 )
             )
@@ -53,17 +53,17 @@ def aws_kms_master_key_provider(**kwargs):
 
     botocore_session = botocore.session.Session(profile=profile_name)
     botocore_session.user_agent_extra = USER_AGENT_SUFFIX
-    kwargs['botocore_session'] = botocore_session
+    kwargs["botocore_session"] = botocore_session
 
     try:
-        region_name = kwargs.pop('region')
+        region_name = kwargs.pop("region")
         if len(region_name) != 1:
             raise BadUserArgumentError(
-                'Only one region may be specified per master key provider configuration. {} provided.'.format(
+                "Only one region may be specified per master key provider configuration. {} provided.".format(
                     len(region_name)
                 )
             )
-        kwargs['region_names'] = region_name
+        kwargs["region_names"] = region_name
     except KeyError:
         pass
     return KMSMasterKeyProvider(**kwargs)

--- a/src/aws_encryption_sdk_cli/key_providers.py
+++ b/src/aws_encryption_sdk_cli/key_providers.py
@@ -13,8 +13,8 @@
 """Master key providers."""
 import copy
 
-from aws_encryption_sdk import KMSMasterKeyProvider
 import botocore.session
+from aws_encryption_sdk import KMSMasterKeyProvider
 
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX

--- a/src/pylintrc
+++ b/src/pylintrc
@@ -2,8 +2,9 @@
 # Disabling messages that we either don't care about
 # for tests or are necessary to break for tests.
 #
+# C0330 : bad-continuation (we let black handle this)
 # R0801 : duplicate-code (we have several functions in io_handling with similar profiles)
-disable = R0801
+disable = C0330, R0801
 
 [BASIC]
 # Allow function names up to 50 characters

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -11,10 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Utility functions to handle configuration, credentials setup, and test skip decision making for integration tests."""
-from distutils.spawn import find_executable  # distutils confuses pylint: disable=import-error,no-name-in-module
 import logging
 import os
 import platform
+from distutils.spawn import find_executable  # distutils confuses pylint: disable=import-error,no-name-in-module
 
 import pytest
 import six

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -21,8 +21,8 @@ import six
 
 from aws_encryption_sdk_cli.internal import logging_utils
 
-WINDOWS_SKIP_MESSAGE = 'Skipping test on Windows'
-AWS_KMS_KEY_ID = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID'
+WINDOWS_SKIP_MESSAGE = "Skipping test on Windows"
+AWS_KMS_KEY_ID = "AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID"
 
 
 def is_windows():
@@ -30,9 +30,9 @@ def is_windows():
 
 
 def aws_encryption_cli_is_findable():
-    path = find_executable('aws-encryption-cli')
+    path = find_executable("aws-encryption-cli")
     if path is None:
-        UserWarning('aws-encryption-cli executable could not be found')
+        UserWarning("aws-encryption-cli executable could not be found")
         return False
     return True
 
@@ -47,36 +47,36 @@ def cmk_arn():
                 AWS_KMS_KEY_ID
             )
         )
-    if arn.startswith('arn:') and ':alias/' not in arn:
+    if arn.startswith("arn:") and ":alias/" not in arn:
         return arn
-    raise ValueError('KMS CMK ARN provided for integration tests must be a key not an alias')
+    raise ValueError("KMS CMK ARN provided for integration tests must be a key not an alias")
 
 
 def encrypt_args_template(metadata=False, caching=False, encode=False, decode=False):
-    template = '-e -i {source} -o {target} --encryption-context a=b c=d -m key=' + cmk_arn()
+    template = "-e -i {source} -o {target} --encryption-context a=b c=d -m key=" + cmk_arn()
     if metadata:
-        template += ' {metadata}'
+        template += " {metadata}"
     else:
-        template += ' -S'
+        template += " -S"
     if caching:
-        template += ' --caching capacity=10 max_age=60.0'
+        template += " --caching capacity=10 max_age=60.0"
     if encode:
-        template += ' --encode'
+        template += " --encode"
     if decode:
-        template += ' --decode'
+        template += " --decode"
     return template
 
 
 def decrypt_args_template(metadata=False, encode=False, decode=False):
-    template = '-d -i {source} -o {target}'
+    template = "-d -i {source} -o {target}"
     if metadata:
-        template += ' {metadata}'
+        template += " {metadata}"
     else:
-        template += ' -S'
+        template += " -S"
     if encode:
-        template += ' --encode'
+        template += " --encode"
     if decode:
-        template += ' --decode'
+        template += " --decode"
     return template
 
 

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -24,49 +24,49 @@ import pytest
 import aws_encryption_sdk_cli
 
 from .integration_test_utils import (
-    WINDOWS_SKIP_MESSAGE, aws_encryption_cli_is_findable, decrypt_args_template, encrypt_args_template, is_windows
+    WINDOWS_SKIP_MESSAGE,
+    aws_encryption_cli_is_findable,
+    decrypt_args_template,
+    encrypt_args_template,
+    is_windows,
 )
 
 pytestmark = pytest.mark.integ
 
 
 def test_encrypt_with_metadata_output_write_to_file(tmpdir):
-    plaintext = tmpdir.join('source_plaintext')
+    plaintext = tmpdir.join("source_plaintext")
     plaintext.write_binary(os.urandom(1024))
-    ciphertext = tmpdir.join('ciphertext')
-    metadata = tmpdir.join('metadata')
+    ciphertext = tmpdir.join("ciphertext")
+    metadata = tmpdir.join("metadata")
 
     encrypt_args = encrypt_args_template(metadata=True).format(
-        source=str(plaintext),
-        target=str(ciphertext),
-        metadata='--metadata-output ' + str(metadata)
+        source=str(plaintext), target=str(ciphertext), metadata="--metadata-output " + str(metadata)
     )
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     raw_metadata = metadata.read()
     output_metadata = json.loads(raw_metadata)
-    for key, value in (('a', 'b'), ('c', 'd')):
-        assert output_metadata['header']['encryption_context'][key] == value
-    assert output_metadata['mode'] == 'encrypt'
-    assert output_metadata['input'] == str(plaintext)
-    assert output_metadata['output'] == str(ciphertext)
+    for key, value in (("a", "b"), ("c", "d")):
+        assert output_metadata["header"]["encryption_context"][key] == value
+    assert output_metadata["mode"] == "encrypt"
+    assert output_metadata["input"] == str(plaintext)
+    assert output_metadata["output"] == str(ciphertext)
 
 
 def test_encrypt_with_metadata_full_file_path(tmpdir):
-    plaintext_filename = 'source_plaintext'
+    plaintext_filename = "source_plaintext"
     plaintext_file = tmpdir.join(plaintext_filename)
     plaintext_file.write_binary(os.urandom(1024))
     plaintext_file_full_path = str(plaintext_file)
-    ciphertext_filename = 'ciphertext'
+    ciphertext_filename = "ciphertext"
     ciphertext_file = tmpdir.join(ciphertext_filename)
     ciphertext_file_full_path = str(ciphertext_file)
-    metadata = tmpdir.join('metadata')
+    metadata = tmpdir.join("metadata")
 
     encrypt_args = encrypt_args_template(metadata=True).format(
-        source=plaintext_filename,
-        target=ciphertext_filename,
-        metadata='--metadata-output ' + str(metadata)
+        source=plaintext_filename, target=ciphertext_filename, metadata="--metadata-output " + str(metadata)
     )
 
     with tmpdir.as_cwd():
@@ -74,48 +74,42 @@ def test_encrypt_with_metadata_full_file_path(tmpdir):
 
     raw_metadata = metadata.read()
     output_metadata = json.loads(raw_metadata)
-    assert output_metadata['input'] == plaintext_file_full_path
-    assert output_metadata['output'] == ciphertext_file_full_path
+    assert output_metadata["input"] == plaintext_file_full_path
+    assert output_metadata["output"] == ciphertext_file_full_path
 
 
 def test_encrypt_with_metadata_output_write_to_stdout(tmpdir, capsys):
-    plaintext = tmpdir.join('source_plaintext')
+    plaintext = tmpdir.join("source_plaintext")
     plaintext.write_binary(os.urandom(1024))
-    ciphertext = tmpdir.join('ciphertext')
+    ciphertext = tmpdir.join("ciphertext")
 
     encrypt_args = encrypt_args_template(metadata=True).format(
-        source=str(plaintext),
-        target=str(ciphertext),
-        metadata='--metadata-output -'
+        source=str(plaintext), target=str(ciphertext), metadata="--metadata-output -"
     )
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     out, _err = capsys.readouterr()
     output_metadata = json.loads(out)
-    for key, value in (('a', 'b'), ('c', 'd')):
-        assert output_metadata['header']['encryption_context'][key] == value
-    assert output_metadata['mode'] == 'encrypt'
-    assert output_metadata['input'] == str(plaintext)
-    assert output_metadata['output'] == str(ciphertext)
+    for key, value in (("a", "b"), ("c", "d")):
+        assert output_metadata["header"]["encryption_context"][key] == value
+    assert output_metadata["mode"] == "encrypt"
+    assert output_metadata["input"] == str(plaintext)
+    assert output_metadata["output"] == str(ciphertext)
 
 
 def test_cycle_with_metadata_output_append(tmpdir):
-    plaintext = tmpdir.join('source_plaintext')
+    plaintext = tmpdir.join("source_plaintext")
     plaintext.write_binary(os.urandom(1024))
-    ciphertext = tmpdir.join('ciphertext')
-    decrypted = tmpdir.join('decrypted')
-    metadata = tmpdir.join('metadata')
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    metadata = tmpdir.join("metadata")
 
     encrypt_args = encrypt_args_template(metadata=True).format(
-        source=str(plaintext),
-        target=str(ciphertext),
-        metadata='--metadata-output ' + str(metadata)
+        source=str(plaintext), target=str(ciphertext), metadata="--metadata-output " + str(metadata)
     )
     decrypt_args = decrypt_args_template(metadata=True).format(
-        source=str(ciphertext),
-        target=str(decrypted),
-        metadata='--metadata-output ' + str(metadata)
+        source=str(ciphertext), target=str(decrypted), metadata="--metadata-output " + str(metadata)
     )
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
@@ -123,44 +117,33 @@ def test_cycle_with_metadata_output_append(tmpdir):
 
     output_metadata = [json.loads(line) for line in metadata.readlines()]
     for line in output_metadata:
-        for key, value in (('a', 'b'), ('c', 'd')):
-            assert line['header']['encryption_context'][key] == value
+        for key, value in (("a", "b"), ("c", "d")):
+            assert line["header"]["encryption_context"][key] == value
 
-    assert output_metadata[0]['mode'] == 'encrypt'
-    assert output_metadata[0]['input'] == str(plaintext)
-    assert output_metadata[0]['output'] == str(ciphertext)
-    assert 'header_auth' not in output_metadata[0]
-    assert output_metadata[1]['mode'] == 'decrypt'
-    assert output_metadata[1]['input'] == str(ciphertext)
-    assert output_metadata[1]['output'] == str(decrypted)
-    assert 'header_auth' in output_metadata[1]
+    assert output_metadata[0]["mode"] == "encrypt"
+    assert output_metadata[0]["input"] == str(plaintext)
+    assert output_metadata[0]["output"] == str(ciphertext)
+    assert "header_auth" not in output_metadata[0]
+    assert output_metadata[1]["mode"] == "decrypt"
+    assert output_metadata[1]["input"] == str(ciphertext)
+    assert output_metadata[1]["output"] == str(decrypted)
+    assert "header_auth" in output_metadata[1]
 
 
-@pytest.mark.parametrize('required_encryption_context', (
-    'a',
-    'c',
-    'a c',
-    'a=b',
-    'a=b c',
-    'c=d',
-    'a c=d',
-    'a=b c=d',
-))
+@pytest.mark.parametrize("required_encryption_context", ("a", "c", "a c", "a=b", "a=b c", "c=d", "a c=d", "a=b c=d"))
 def test_file_to_file_decrypt_required_encryption_context_success(tmpdir, required_encryption_context):
-    plaintext = tmpdir.join('source_plaintext')
-    ciphertext = tmpdir.join('ciphertext')
-    decrypted = tmpdir.join('decrypted')
-    with open(str(plaintext), 'wb') as f:
+    plaintext = tmpdir.join("source_plaintext")
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    with open(str(plaintext), "wb") as f:
         f.write(os.urandom(1024))
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext),
-        target=str(ciphertext)
+    encrypt_args = encrypt_args_template().format(source=str(plaintext), target=str(ciphertext))
+    decrypt_args = (
+        decrypt_args_template().format(source=str(ciphertext), target=str(decrypted))
+        + " --encryption-context "
+        + required_encryption_context
     )
-    decrypt_args = decrypt_args_template().format(
-        source=str(ciphertext),
-        target=str(decrypted)
-    ) + ' --encryption-context ' + required_encryption_context
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
@@ -168,23 +151,22 @@ def test_file_to_file_decrypt_required_encryption_context_success(tmpdir, requir
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.parametrize('required_encryption_context', ('a=VALUE_NOT_FOUND', 'KEY_NOT_FOUND'))
+@pytest.mark.parametrize("required_encryption_context", ("a=VALUE_NOT_FOUND", "KEY_NOT_FOUND"))
 def test_file_to_file_decrypt_required_encryption_context_fail(tmpdir, required_encryption_context):
-    plaintext = tmpdir.join('source_plaintext')
+    plaintext = tmpdir.join("source_plaintext")
     plaintext.write_binary(os.urandom(1024))
-    ciphertext = tmpdir.join('ciphertext')
-    metadata_file = tmpdir.join('metadata')
-    decrypted = tmpdir.join('decrypted')
+    ciphertext = tmpdir.join("ciphertext")
+    metadata_file = tmpdir.join("metadata")
+    decrypted = tmpdir.join("decrypted")
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext),
-        target=str(ciphertext)
+    encrypt_args = encrypt_args_template().format(source=str(plaintext), target=str(ciphertext))
+    decrypt_args = (
+        decrypt_args_template(metadata=True).format(
+            source=str(ciphertext), target=str(decrypted), metadata=" --metadata-output " + str(metadata_file)
+        )
+        + " --encryption-context "
+        + required_encryption_context
     )
-    decrypt_args = decrypt_args_template(metadata=True).format(
-        source=str(ciphertext),
-        target=str(decrypted),
-        metadata=' --metadata-output ' + str(metadata_file)
-    ) + ' --encryption-context ' + required_encryption_context
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
@@ -192,25 +174,19 @@ def test_file_to_file_decrypt_required_encryption_context_fail(tmpdir, required_
     assert not decrypted.isfile()
     raw_metadata = metadata_file.read()
     parsed_metadata = json.loads(raw_metadata)
-    assert parsed_metadata['skipped']
-    assert parsed_metadata['reason'] == 'Missing encryption context key or value'
+    assert parsed_metadata["skipped"]
+    assert parsed_metadata["reason"] == "Missing encryption context key or value"
 
 
 def test_file_to_file_cycle(tmpdir):
-    plaintext = tmpdir.join('source_plaintext')
-    ciphertext = tmpdir.join('ciphertext')
-    decrypted = tmpdir.join('decrypted')
-    with open(str(plaintext), 'wb') as f:
+    plaintext = tmpdir.join("source_plaintext")
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    with open(str(plaintext), "wb") as f:
         f.write(os.urandom(1024))
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext),
-        target=str(ciphertext)
-    )
-    decrypt_args = decrypt_args_template().format(
-        source=str(ciphertext),
-        target=str(decrypted)
-    )
+    encrypt_args = encrypt_args_template().format(source=str(plaintext), target=str(ciphertext))
+    decrypt_args = decrypt_args_template().format(source=str(ciphertext), target=str(decrypted))
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
@@ -220,22 +196,16 @@ def test_file_to_file_cycle(tmpdir):
 
 @pytest.mark.skipif(is_windows(), reason=WINDOWS_SKIP_MESSAGE)
 def test_file_to_file_cycle_target_through_symlink(tmpdir):
-    plaintext = tmpdir.join('source_plaintext')
-    output_dir = tmpdir.mkdir('output')
-    os.symlink(str(output_dir), str(tmpdir.join('output_link')))
-    ciphertext = tmpdir.join('output_link', 'ciphertext')
-    decrypted = tmpdir.join('decrypted')
-    with open(str(plaintext), 'wb') as f:
+    plaintext = tmpdir.join("source_plaintext")
+    output_dir = tmpdir.mkdir("output")
+    os.symlink(str(output_dir), str(tmpdir.join("output_link")))
+    ciphertext = tmpdir.join("output_link", "ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    with open(str(plaintext), "wb") as f:
         f.write(os.urandom(1024))
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext),
-        target=str(ciphertext)
-    )
-    decrypt_args = decrypt_args_template().format(
-        source=str(ciphertext),
-        target=str(decrypted)
-    )
+    encrypt_args = encrypt_args_template().format(source=str(plaintext), target=str(ciphertext))
+    decrypt_args = decrypt_args_template().format(source=str(ciphertext), target=str(decrypted))
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
@@ -243,68 +213,51 @@ def test_file_to_file_cycle_target_through_symlink(tmpdir):
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.parametrize('encode, decode', (
-    (True, False),
-    (False, True),
-    (True, True),
-    (False, False)
-))
+@pytest.mark.parametrize("encode, decode", ((True, False), (False, True), (True, True), (False, False)))
 def test_file_to_file_base64(tmpdir, encode, decode):
-    plaintext = tmpdir.join('source_plaintext')
-    ciphertext_a = tmpdir.join('ciphertext-a')
-    ciphertext_b = tmpdir.join('ciphertext-b')
-    decrypted = tmpdir.join('decrypted')
+    plaintext = tmpdir.join("source_plaintext")
+    ciphertext_a = tmpdir.join("ciphertext-a")
+    ciphertext_b = tmpdir.join("ciphertext-b")
+    decrypted = tmpdir.join("decrypted")
     plaintext_source = os.urandom(10240)  # make sure we have more than one chunk
-    with open(str(plaintext), 'wb') as f:
+    with open(str(plaintext), "wb") as f:
         f.write(plaintext_source)
 
-    encrypt_flag = ' --encode' if encode else ''
-    decrypt_flag = ' --decode' if decode else ''
+    encrypt_flag = " --encode" if encode else ""
+    decrypt_flag = " --decode" if decode else ""
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext),
-        target=str(ciphertext_a)
-    ) + encrypt_flag
-    decrypt_args = decrypt_args_template().format(
-        source=str(ciphertext_b),
-        target=str(decrypted)
-    ) + decrypt_flag
+    encrypt_args = encrypt_args_template().format(source=str(plaintext), target=str(ciphertext_a)) + encrypt_flag
+    decrypt_args = decrypt_args_template().format(source=str(ciphertext_b), target=str(decrypted)) + decrypt_flag
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     if encode and not decode:
-        with open(str(ciphertext_a), 'rb') as ct_a, open(str(ciphertext_b), 'wb') as ct_b:
+        with open(str(ciphertext_a), "rb") as ct_a, open(str(ciphertext_b), "wb") as ct_b:
             raw_ct = base64.b64decode(ct_a.read())
             ct_b.write(raw_ct)
     elif decode and not encode:
-        with open(str(ciphertext_a), 'rb') as ct, open(str(ciphertext_b), 'wb') as b64_ct:
+        with open(str(ciphertext_a), "rb") as ct, open(str(ciphertext_b), "wb") as b64_ct:
             b64_ct.write(base64.b64encode(ct.read()))
     else:
         shutil.copy2(str(ciphertext_a), str(ciphertext_b))
 
     aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
 
-    with open(str(decrypted), 'rb') as f:
+    with open(str(decrypted), "rb") as f:
         decrypted_plaintext = f.read()
 
     assert decrypted_plaintext == plaintext_source
 
 
 def test_file_to_file_cycle_with_caching(tmpdir):
-    plaintext = tmpdir.join('source_plaintext')
-    ciphertext = tmpdir.join('ciphertext')
-    decrypted = tmpdir.join('decrypted')
-    with open(str(plaintext), 'wb') as f:
+    plaintext = tmpdir.join("source_plaintext")
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    with open(str(plaintext), "wb") as f:
         f.write(os.urandom(1024))
 
-    encrypt_args = encrypt_args_template(caching=True).format(
-        source=str(plaintext),
-        target=str(ciphertext)
-    )
-    decrypt_args = decrypt_args_template().format(
-        source=str(ciphertext),
-        target=str(decrypted)
-    )
+    encrypt_args = encrypt_args_template(caching=True).format(source=str(plaintext), target=str(ciphertext))
+    decrypt_args = decrypt_args_template().format(source=str(ciphertext), target=str(decrypted))
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
@@ -314,77 +267,62 @@ def test_file_to_file_cycle_with_caching(tmpdir):
 
 def test_file_overwrite_source_file_to_file_custom_empty_prefix(tmpdir):
     plaintext_source = os.urandom(2014)
-    plaintext = tmpdir.join('source_plaintext')
-    with open(str(plaintext), 'wb') as f:
+    plaintext = tmpdir.join("source_plaintext")
+    with open(str(plaintext), "wb") as f:
         f.write(plaintext_source)
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext),
-        target=str(plaintext)
-    ) + ' --suffix'
+    encrypt_args = encrypt_args_template().format(source=str(plaintext), target=str(plaintext)) + " --suffix"
 
     test_result = aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
-    assert test_result == 'Destination and source cannot be the same'
+    assert test_result == "Destination and source cannot be the same"
 
-    with open(str(plaintext), 'rb') as f:
+    with open(str(plaintext), "rb") as f:
         assert f.read() == plaintext_source
 
 
 def test_file_overwrite_source_dir_to_dir_custom_empty_prefix(tmpdir):
     plaintext_source = os.urandom(2014)
-    plaintext = tmpdir.join('source_plaintext')
-    with open(str(plaintext), 'wb') as f:
+    plaintext = tmpdir.join("source_plaintext")
+    with open(str(plaintext), "wb") as f:
         f.write(plaintext_source)
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(tmpdir),
-        target=str(tmpdir)
-    ) + ' --suffix'
+    encrypt_args = encrypt_args_template().format(source=str(tmpdir), target=str(tmpdir)) + " --suffix"
 
     test_result = aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
-    assert test_result == 'Destination and source cannot be the same'
+    assert test_result == "Destination and source cannot be the same"
 
-    with open(str(plaintext), 'rb') as f:
+    with open(str(plaintext), "rb") as f:
         assert f.read() == plaintext_source
 
 
 def test_file_overwrite_source_file_to_dir_custom_empty_prefix(tmpdir):
     plaintext_source = os.urandom(2014)
-    plaintext = tmpdir.join('source_plaintext')
-    with open(str(plaintext), 'wb') as f:
+    plaintext = tmpdir.join("source_plaintext")
+    with open(str(plaintext), "wb") as f:
         f.write(plaintext_source)
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext),
-        target=str(tmpdir)
-    ) + ' --suffix'
+    encrypt_args = encrypt_args_template().format(source=str(plaintext), target=str(tmpdir)) + " --suffix"
 
     test_result = aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 
     assert test_result is None
 
-    with open(str(plaintext), 'rb') as f:
+    with open(str(plaintext), "rb") as f:
         assert f.read() == plaintext_source
 
 
 def test_file_to_dir_cycle(tmpdir):
-    inner_dir = tmpdir.mkdir('inner')
-    plaintext = tmpdir.join('source_plaintext')
-    ciphertext = inner_dir.join('source_plaintext.encrypted')
-    decrypted = tmpdir.join('decrypted')
-    with open(str(plaintext), 'wb') as f:
+    inner_dir = tmpdir.mkdir("inner")
+    plaintext = tmpdir.join("source_plaintext")
+    ciphertext = inner_dir.join("source_plaintext.encrypted")
+    decrypted = tmpdir.join("decrypted")
+    with open(str(plaintext), "wb") as f:
         f.write(os.urandom(1024))
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext),
-        target=str(inner_dir)
-    )
-    decrypt_args = decrypt_args_template().format(
-        source=str(ciphertext),
-        target=str(decrypted)
-    )
+    encrypt_args = encrypt_args_template().format(source=str(plaintext), target=str(inner_dir))
+    decrypt_args = decrypt_args_template().format(source=str(ciphertext), target=str(decrypted))
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     assert os.path.isfile(str(ciphertext))
@@ -393,18 +331,16 @@ def test_file_to_dir_cycle(tmpdir):
     assert filecmp.cmp(str(plaintext), str(decrypted))
 
 
-@pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
+@pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason="aws-encryption-cli executable could not be found.")
 def test_stdin_to_file_to_stdout_cycle(tmpdir):
-    ciphertext_file = tmpdir.join('ciphertext')
+    ciphertext_file = tmpdir.join("ciphertext")
     plaintext = os.urandom(1024)
 
-    encrypt_args = 'aws-encryption-cli ' + encrypt_args_template(decode=True).format(
-        source='-',
-        target=str(ciphertext_file)
+    encrypt_args = "aws-encryption-cli " + encrypt_args_template(decode=True).format(
+        source="-", target=str(ciphertext_file)
     )
-    decrypt_args = 'aws-encryption-cli ' + decrypt_args_template(encode=True).format(
-        source=str(ciphertext_file),
-        target='-'
+    decrypt_args = "aws-encryption-cli " + decrypt_args_template(encode=True).format(
+        source=str(ciphertext_file), target="-"
     )
 
     proc = Popen(shlex.split(encrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
@@ -416,17 +352,15 @@ def test_stdin_to_file_to_stdout_cycle(tmpdir):
     assert base64.b64decode(decrypted_stdout) == plaintext
 
 
-@pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
+@pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason="aws-encryption-cli executable could not be found.")
 def test_stdin_stdout_stdin_stdout_cycle():
     plaintext = os.urandom(1024)
 
-    encrypt_args = 'aws-encryption-cli ' + encrypt_args_template(decode=True, encode=True).format(
-        source='-',
-        target='-'
+    encrypt_args = "aws-encryption-cli " + encrypt_args_template(decode=True, encode=True).format(
+        source="-", target="-"
     )
-    decrypt_args = 'aws-encryption-cli ' + decrypt_args_template(decode=True, encode=True).format(
-        source='-',
-        target='-'
+    decrypt_args = "aws-encryption-cli " + decrypt_args_template(decode=True, encode=True).format(
+        source="-", target="-"
     )
     proc = Popen(shlex.split(encrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
     ciphertext, _stderr = proc.communicate(input=base64.b64encode(plaintext))
@@ -436,59 +370,53 @@ def test_stdin_stdout_stdin_stdout_cycle():
     assert base64.b64decode(decrypted_stdout) == plaintext
 
 
-@pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason='aws-encryption-cli executable could not be found.')
-@pytest.mark.parametrize('required_encryption_context', ('a=VALUE_NOT_FOUND', 'KEY_NOT_FOUND'))
+@pytest.mark.skipif(not aws_encryption_cli_is_findable(), reason="aws-encryption-cli executable could not be found.")
+@pytest.mark.parametrize("required_encryption_context", ("a=VALUE_NOT_FOUND", "KEY_NOT_FOUND"))
 def test_file_to_stdout_decrypt_required_encryption_context_fail(tmpdir, required_encryption_context):
-    plaintext = tmpdir.join('source_plaintext')
+    plaintext = tmpdir.join("source_plaintext")
     plaintext.write_binary(os.urandom(1024))
-    ciphertext = tmpdir.join('ciphertext')
-    metadata_file = tmpdir.join('metadata')
+    ciphertext = tmpdir.join("ciphertext")
+    metadata_file = tmpdir.join("metadata")
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext),
-        target=str(ciphertext)
+    encrypt_args = encrypt_args_template().format(source=str(plaintext), target=str(ciphertext))
+    decrypt_args = (
+        "aws-encryption-cli "
+        + decrypt_args_template(metadata=True).format(
+            source=str(ciphertext), target="-", metadata=" --metadata-output " + str(metadata_file)
+        )
+        + " --encryption-context "
+        + required_encryption_context
     )
-    decrypt_args = 'aws-encryption-cli ' + decrypt_args_template(metadata=True).format(
-        source=str(ciphertext),
-        target='-',
-        metadata=' --metadata-output ' + str(metadata_file)
-    ) + ' --encryption-context ' + required_encryption_context
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     proc = Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
     decrypted_output, stderr = proc.communicate()
 
     # Verify that no output was written
-    assert decrypted_output == b''
+    assert decrypted_output == b""
     # Verify the no exception was raised trying to delete verifiable non-existant "-" file,
     # to verify that we did not attempt to do that
-    assert b'OSError' not in stderr  # Python 2
-    assert b'FileNotFoundError' not in stderr  # Python 3
+    assert b"OSError" not in stderr  # Python 2
+    assert b"FileNotFoundError" not in stderr  # Python 3
     raw_metadata = metadata_file.read()
     parsed_metadata = json.loads(raw_metadata)
-    assert parsed_metadata['output'] == '<stdout>'
-    assert parsed_metadata['skipped']
-    assert parsed_metadata['reason'] == 'Missing encryption context key or value'
+    assert parsed_metadata["output"] == "<stdout>"
+    assert parsed_metadata["skipped"]
+    assert parsed_metadata["reason"] == "Missing encryption context key or value"
 
 
 def test_dir_to_dir_cycle(tmpdir):
-    plaintext_dir = tmpdir.mkdir('plaintext')
-    ciphertext_dir = tmpdir.mkdir('ciphertext')
-    decrypted_dir = tmpdir.mkdir('decrypted')
-    plaintext_dir.mkdir('a').mkdir('b')
-    plaintext_dir.mkdir('c')
-    for source_file_path in (['1'], ['a', '2'], ['a', 'b', '3'], ['c', '4']):
-        with open(os.path.join(str(plaintext_dir), *source_file_path), 'wb') as file:
+    plaintext_dir = tmpdir.mkdir("plaintext")
+    ciphertext_dir = tmpdir.mkdir("ciphertext")
+    decrypted_dir = tmpdir.mkdir("decrypted")
+    plaintext_dir.mkdir("a").mkdir("b")
+    plaintext_dir.mkdir("c")
+    for source_file_path in (["1"], ["a", "2"], ["a", "b", "3"], ["c", "4"]):
+        with open(os.path.join(str(plaintext_dir), *source_file_path), "wb") as file:
             file.write(os.urandom(1024))
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext_dir),
-        target=str(ciphertext_dir)
-    ) + ' -r'
-    decrypt_args = decrypt_args_template().format(
-        source=str(ciphertext_dir),
-        target=str(decrypted_dir)
-    ) + ' -r'
+    encrypt_args = encrypt_args_template().format(source=str(plaintext_dir), target=str(ciphertext_dir)) + " -r"
+    decrypt_args = decrypt_args_template().format(source=str(ciphertext_dir), target=str(decrypted_dir)) + " -r"
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
@@ -496,33 +424,36 @@ def test_dir_to_dir_cycle(tmpdir):
     for base_dir, _dirs, filenames in os.walk(str(plaintext_dir)):
         for file in filenames:
             plaintext_filename = os.path.join(base_dir, file)
-            decrypted_filename = plaintext_filename.replace(
-                str(plaintext_dir),
-                str(decrypted_dir)
-            ) + '.encrypted.decrypted'
+            decrypted_filename = (
+                plaintext_filename.replace(str(plaintext_dir), str(decrypted_dir)) + ".encrypted.decrypted"
+            )
             assert filecmp.cmp(plaintext_filename, decrypted_filename)
 
 
 def test_dir_to_dir_cycle_custom_suffix(tmpdir):
-    plaintext_dir = tmpdir.mkdir('plaintext')
-    ciphertext_dir = tmpdir.mkdir('ciphertext')
-    decrypted_dir = tmpdir.mkdir('decrypted')
-    plaintext_dir.mkdir('a').mkdir('b')
-    plaintext_dir.mkdir('c')
-    for source_file_path in (['1'], ['a', '2'], ['a', 'b', '3'], ['c', '4']):
-        with open(os.path.join(str(plaintext_dir), *source_file_path), 'wb') as file:
+    plaintext_dir = tmpdir.mkdir("plaintext")
+    ciphertext_dir = tmpdir.mkdir("ciphertext")
+    decrypted_dir = tmpdir.mkdir("decrypted")
+    plaintext_dir.mkdir("a").mkdir("b")
+    plaintext_dir.mkdir("c")
+    for source_file_path in (["1"], ["a", "2"], ["a", "b", "3"], ["c", "4"]):
+        with open(os.path.join(str(plaintext_dir), *source_file_path), "wb") as file:
             file.write(os.urandom(1024))
 
-    encrypt_suffix = 'THIS_IS_A_CUSTOM_SUFFIX'
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext_dir),
-        target=str(ciphertext_dir)
-    ) + ' -r' + ' --suffix ' + encrypt_suffix
-    decrypt_suffix = '.anotherSuffix'
-    decrypt_args = decrypt_args_template().format(
-        source=str(ciphertext_dir),
-        target=str(decrypted_dir)
-    ) + ' -r' + ' --suffix ' + decrypt_suffix
+    encrypt_suffix = "THIS_IS_A_CUSTOM_SUFFIX"
+    encrypt_args = (
+        encrypt_args_template().format(source=str(plaintext_dir), target=str(ciphertext_dir))
+        + " -r"
+        + " --suffix "
+        + encrypt_suffix
+    )
+    decrypt_suffix = ".anotherSuffix"
+    decrypt_args = (
+        decrypt_args_template().format(source=str(ciphertext_dir), target=str(decrypted_dir))
+        + " -r"
+        + " --suffix "
+        + decrypt_suffix
+    )
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
@@ -530,31 +461,29 @@ def test_dir_to_dir_cycle_custom_suffix(tmpdir):
     for base_dir, _dirs, filenames in os.walk(str(plaintext_dir)):
         for file in filenames:
             plaintext_filename = os.path.join(base_dir, file)
-            decrypted_filename = plaintext_filename.replace(
-                str(plaintext_dir),
-                str(decrypted_dir)
-            ) + encrypt_suffix + decrypt_suffix
+            decrypted_filename = (
+                plaintext_filename.replace(str(plaintext_dir), str(decrypted_dir)) + encrypt_suffix + decrypt_suffix
+            )
             assert filecmp.cmp(plaintext_filename, decrypted_filename)
 
 
 def test_glob_to_dir_cycle(tmpdir):
-    plaintext_dir = tmpdir.mkdir('plaintext')
-    ciphertext_dir = tmpdir.mkdir('ciphertext')
-    decrypted_dir = tmpdir.mkdir('decrypted')
-    for source_file_path in ('a.1', 'b.2', 'b.1', 'c.1'):
-        with open(os.path.join(str(plaintext_dir), source_file_path), 'wb') as file:
+    plaintext_dir = tmpdir.mkdir("plaintext")
+    ciphertext_dir = tmpdir.mkdir("ciphertext")
+    decrypted_dir = tmpdir.mkdir("decrypted")
+    for source_file_path in ("a.1", "b.2", "b.1", "c.1"):
+        with open(os.path.join(str(plaintext_dir), source_file_path), "wb") as file:
             file.write(os.urandom(1024))
 
-    suffix = '.1'
+    suffix = ".1"
 
-    encrypt_args = encrypt_args_template().format(
-        source=os.path.join(str(plaintext_dir), '*' + suffix),
-        target=str(ciphertext_dir)
-    ) + ' -r'
-    decrypt_args = decrypt_args_template().format(
-        source=str(ciphertext_dir),
-        target=str(decrypted_dir)
-    ) + ' -r'
+    encrypt_args = (
+        encrypt_args_template().format(
+            source=os.path.join(str(plaintext_dir), "*" + suffix), target=str(ciphertext_dir)
+        )
+        + " -r"
+    )
+    decrypt_args = decrypt_args_template().format(source=str(ciphertext_dir), target=str(decrypted_dir)) + " -r"
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
     aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
@@ -562,10 +491,9 @@ def test_glob_to_dir_cycle(tmpdir):
     for base_dir, _dirs, filenames in os.walk(str(plaintext_dir)):
         for file in filenames:
             plaintext_filename = os.path.join(base_dir, file)
-            decrypted_filename = plaintext_filename.replace(
-                str(plaintext_dir),
-                str(decrypted_dir)
-            ) + '.encrypted.decrypted'
+            decrypted_filename = (
+                plaintext_filename.replace(str(plaintext_dir), str(decrypted_dir)) + ".encrypted.decrypted"
+            )
 
             if plaintext_filename.endswith(suffix):
                 assert filecmp.cmp(plaintext_filename, decrypted_filename)

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -22,9 +22,9 @@ from subprocess import PIPE, Popen
 import pytest
 
 import aws_encryption_sdk_cli
+
 from .integration_test_utils import (
-    aws_encryption_cli_is_findable, decrypt_args_template,
-    encrypt_args_template, is_windows, WINDOWS_SKIP_MESSAGE
+    WINDOWS_SKIP_MESSAGE, aws_encryption_cli_is_findable, decrypt_args_template, encrypt_args_template, is_windows
 )
 
 pytestmark = pytest.mark.integ

--- a/test/integration/test_i_key_providers.py
+++ b/test/integration/test_i_key_providers.py
@@ -18,8 +18,10 @@ import pytest
 
 import aws_encryption_sdk_cli
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
-from .integration_test_utils import encrypt_args_template
-from .integration_test_utils import is_windows, kms_redacting_logger_stream  # noqa pylint: disable=unused-import
+
+from .integration_test_utils import encrypt_args_template, is_windows
+
+from .integration_test_utils import kms_redacting_logger_stream  # isort:skip noqa pylint: disable=unused-import
 
 pytestmark = pytest.mark.integ
 

--- a/test/integration/test_i_key_providers.py
+++ b/test/integration/test_i_key_providers.py
@@ -21,20 +21,17 @@ from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
 
 from .integration_test_utils import encrypt_args_template, is_windows
 
-from .integration_test_utils import kms_redacting_logger_stream  # isort:skip noqa pylint: disable=unused-import
+from .integration_test_utils import kms_redacting_logger_stream  # noqa isort:skip pylint: disable=unused-import
 
 pytestmark = pytest.mark.integ
 
 
 def test_encrypt_verify_user_agent(tmpdir, kms_redacting_logger_stream):
-    plaintext = tmpdir.join('source_plaintext')
+    plaintext = tmpdir.join("source_plaintext")
     plaintext.write_binary(os.urandom(1024))
-    ciphertext = tmpdir.join('ciphertext')
+    ciphertext = tmpdir.join("ciphertext")
 
-    encrypt_args = encrypt_args_template().format(
-        source=str(plaintext),
-        target=str(ciphertext)
-    ) + ' -vvvv'
+    encrypt_args = encrypt_args_template().format(source=str(plaintext), target=str(ciphertext)) + " -vvvv"
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
 

--- a/test/integration/test_i_logging_utils.py
+++ b/test/integration/test_i_logging_utils.py
@@ -18,6 +18,7 @@ import boto3
 import pytest
 
 from aws_encryption_sdk_cli.internal import logging_utils
+
 from .integration_test_utils import cmk_arn, kms_redacting_logger_stream  # noqa pylint: disable=unused-import
 
 pytestmark = pytest.mark.integ

--- a/test/integration/test_i_logging_utils.py
+++ b/test/integration/test_i_logging_utils.py
@@ -26,8 +26,8 @@ pytestmark = pytest.mark.integ
 
 @pytest.fixture
 def kms_client(cmk_arn):
-    region = cmk_arn.split(':')[3]
-    return boto3.client('kms', region_name=region)
+    region = cmk_arn.split(":")[3]
+    return boto3.client("kms", region_name=region)
 
 
 def test_kms_generate_data_key(kms_redacting_logger_stream, kms_client, cmk_arn):
@@ -37,30 +37,30 @@ def test_kms_generate_data_key(kms_redacting_logger_stream, kms_client, cmk_arn)
 
     assert log_output.count(logging_utils._REDACTED) == 1
     assert log_output.count(cmk_arn) == 2
-    assert codecs.decode(base64.b64encode(response['Plaintext']), 'utf-8') not in log_output
-    assert log_output.count(codecs.decode(base64.b64encode(response['CiphertextBlob']), 'utf-8')) == 1
+    assert codecs.decode(base64.b64encode(response["Plaintext"]), "utf-8") not in log_output
+    assert log_output.count(codecs.decode(base64.b64encode(response["CiphertextBlob"]), "utf-8")) == 1
 
 
 def test_kms_encrypt(kms_redacting_logger_stream, kms_client, cmk_arn):
-    raw_plaintext = b'some secret data'
+    raw_plaintext = b"some secret data"
     response = kms_client.encrypt(KeyId=cmk_arn, Plaintext=raw_plaintext)
 
     log_output = kms_redacting_logger_stream.getvalue()
 
     assert log_output.count(logging_utils._REDACTED) == 1
     assert log_output.count(cmk_arn) == 2
-    assert codecs.decode(base64.b64encode(raw_plaintext), 'utf-8') not in log_output
-    assert log_output.count(codecs.decode(base64.b64encode(response['CiphertextBlob']), 'utf-8')) == 1
+    assert codecs.decode(base64.b64encode(raw_plaintext), "utf-8") not in log_output
+    assert log_output.count(codecs.decode(base64.b64encode(response["CiphertextBlob"]), "utf-8")) == 1
 
 
 def test_kms_decrypt(kms_redacting_logger_stream, kms_client, cmk_arn):
-    raw_plaintext = b'some secret data'
+    raw_plaintext = b"some secret data"
     encrypt_response = kms_client.encrypt(KeyId=cmk_arn, Plaintext=raw_plaintext)
-    kms_client.decrypt(CiphertextBlob=encrypt_response['CiphertextBlob'])
+    kms_client.decrypt(CiphertextBlob=encrypt_response["CiphertextBlob"])
 
     log_output = kms_redacting_logger_stream.getvalue()
 
     assert log_output.count(logging_utils._REDACTED) == 2
     assert log_output.count(cmk_arn) == 3
-    assert codecs.decode(base64.b64encode(raw_plaintext), 'utf-8') not in log_output
-    assert log_output.count(codecs.decode(base64.b64encode(encrypt_response['CiphertextBlob']), 'utf-8')) == 2
+    assert codecs.decode(base64.b64encode(raw_plaintext), "utf-8") not in log_output
+    assert log_output.count(codecs.decode(base64.b64encode(encrypt_response["CiphertextBlob"]), "utf-8")) == 2

--- a/test/pylintrc
+++ b/test/pylintrc
@@ -4,6 +4,7 @@
 #
 # C0103 : invalid-name (we prefer long, descriptive, names for tests)
 # C0111 : missing-docstring (we don't write docstrings for tests)
+# C0330 : bad-continuation (we let black handle this)
 # E1101 : no-member (raised on patched objects with mock checks)
 # R0801 : duplicate-code (unit tests for similar things tend to be similar)
 # R0914 : too-many-locals (we prefer clarity over brevity in tests)
@@ -11,7 +12,7 @@
 # W0212 : protected-access (raised when calling _ methods)
 # W0621 : redefined-outer-name (raised when using pytest-mock)
 # W0613 : unused-argument (raised when patches are needed but not called)
-disable = C0103, C0111, E1101, R0801, R0903, R0914, W0212, W0621, W0613
+disable = C0103, C0111, C0330, E1101, R0801, R0903, R0914, W0212, W0621, W0613
 
 [VARIABLES]
 additional-builtins = raw_input

--- a/test/unit/test_arg_parsing.py
+++ b/test/unit/test_arg_parsing.py
@@ -29,92 +29,82 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 @pytest.fixture
 def patch_platform_win32_ver(mocker):
-    mocker.patch.object(arg_parsing.platform, 'win32_ver')
+    mocker.patch.object(arg_parsing.platform, "win32_ver")
     return arg_parsing.platform.win32_ver
 
 
 @pytest.yield_fixture
 def patch_build_parser(mocker):
-    mocker.patch.object(arg_parsing, '_build_parser')
+    mocker.patch.object(arg_parsing, "_build_parser")
     yield arg_parsing._build_parser
 
 
 @pytest.yield_fixture
 def patch_process_master_key_provider_configs(mocker):
-    mocker.patch.object(arg_parsing, '_process_master_key_provider_configs')
+    mocker.patch.object(arg_parsing, "_process_master_key_provider_configs")
     yield arg_parsing._process_master_key_provider_configs
 
 
 @pytest.yield_fixture
 def patch_parse_and_collapse_config(mocker):
-    mocker.patch.object(arg_parsing, '_parse_and_collapse_config')
+    mocker.patch.object(arg_parsing, "_parse_and_collapse_config")
     yield arg_parsing._parse_and_collapse_config
 
 
 @pytest.yield_fixture
 def patch_process_encryption_context(mocker):
-    mocker.patch.object(arg_parsing, '_process_encryption_context')
+    mocker.patch.object(arg_parsing, "_process_encryption_context")
     arg_parsing._process_encryption_context.return_value = sentinel.encryption_context, sentinel.required_keys
     yield arg_parsing._process_encryption_context
 
 
 @pytest.yield_fixture
 def patch_process_caching_config(mocker):
-    mocker.patch.object(arg_parsing, '_process_caching_config')
+    mocker.patch.object(arg_parsing, "_process_caching_config")
     yield arg_parsing._process_caching_config
 
 
 def test_version_report():
     test = arg_parsing._version_report()
-    assert test == 'aws-encryption-sdk-cli/{cli} aws-encryption-sdk/{sdk}'.format(
-        cli=aws_encryption_sdk_cli.__version__,
-        sdk=aws_encryption_sdk.__version__
+    assert test == "aws-encryption-sdk-cli/{cli} aws-encryption-sdk/{sdk}".format(
+        cli=aws_encryption_sdk_cli.__version__, sdk=aws_encryption_sdk.__version__
     )
 
 
-@pytest.mark.parametrize('arg_line, line_args', (
-    (  # The default converter leaves a space in front of the first argument
-       # when called like this. Make sure we do not.
-        '-f test1 test2',
-        ['-f', 'test1', 'test2']
-    ),
+@pytest.mark.parametrize(
+    "arg_line, line_args",
     (
-        '   test1   test2    ',
-        ['test1', 'test2']
+        (  # The default converter leaves a space in front of the first argument
+            # when called like this. Make sure we do not.
+            "-f test1 test2",
+            ["-f", "test1", "test2"],
+        ),
+        ("   test1   test2    ", ["test1", "test2"]),
+        ("-f test1 test2 # in-line comment", ["-f", "test1", "test2"]),
+        ("# whole-line comment", []),
+        (
+            "-f " + os.path.join("~", "my", "special", "file"),
+            ["-f", os.path.join(os.path.expanduser("~"), "my", "special", "file")],
+        ),
+        ("-f $ANOTHER_VAR ${MY_SPECIAL_VAR}PlusSome", ["-f", "someOtherData", "aVerySpecialPrefixPlusSome"]),
     ),
-    (
-        '-f test1 test2 # in-line comment',
-        ['-f', 'test1', 'test2']
-    ),
-    (
-        '# whole-line comment',
-        []
-    ),
-    (
-        '-f ' + os.path.join('~', 'my', 'special', 'file'),
-        ['-f', os.path.join(os.path.expanduser('~'), 'my', 'special', 'file')]
-    ),
-    (
-        '-f $ANOTHER_VAR ${MY_SPECIAL_VAR}PlusSome',
-        ['-f', 'someOtherData', 'aVerySpecialPrefixPlusSome']
-    )
-))
+)
 def test_comment_ignoring_argument_parser_convert_arg_line_to_args(monkeypatch, arg_line, line_args):
-    monkeypatch.setenv('MY_SPECIAL_VAR', 'aVerySpecialPrefix')
-    monkeypatch.setenv('ANOTHER_VAR', 'someOtherData')
+    monkeypatch.setenv("MY_SPECIAL_VAR", "aVerySpecialPrefix")
+    monkeypatch.setenv("ANOTHER_VAR", "someOtherData")
     parser = arg_parsing.CommentIgnoringArgumentParser()
     parsed_line = [arg for arg in parser.convert_arg_line_to_args(arg_line)]
     assert line_args == parsed_line
 
 
-POSIX_FILEPATH = ('-i test/file/path', ['-i', 'test/file/path'])
-NON_POSIX_FILEPATH = ('-i test\\file\\path', ['-i', 'test\\file\\path'])
+POSIX_FILEPATH = ("-i test/file/path", ["-i", "test/file/path"])
+NON_POSIX_FILEPATH = ("-i test\\file\\path", ["-i", "test\\file\\path"])
 
 
-@pytest.mark.parametrize('win32_version, expected_transform', (
-    (('', '', ''), POSIX_FILEPATH),
-    (('10', '10.0.0', 'SP0', 'Multiprocessor Free'), NON_POSIX_FILEPATH)
-))
+@pytest.mark.parametrize(
+    "win32_version, expected_transform",
+    ((("", "", ""), POSIX_FILEPATH), (("10", "10.0.0", "SP0", "Multiprocessor Free"), NON_POSIX_FILEPATH)),
+)
 def test_comment_ignoring_argument_parser_convert_filename(patch_platform_win32_ver, win32_version, expected_transform):
     patch_platform_win32_ver.return_value = win32_version
     parser = arg_parsing.CommentIgnoringArgumentParser()
@@ -130,35 +120,40 @@ def test_comment_ignoring_argument_parser_convert_filename(patch_platform_win32_
 
 def build_convert_special_cases():
     test_cases = []
-    escape_chars = {
-        False: '\\',
-        True: '`'
-    }
+    escape_chars = {False: "\\", True: "`"}
     for plat_is_windows in (True, False):
-        test_cases.append((
-            '-o "example file with spaces surrounded by double quotes"',
-            ['-o', 'example file with spaces surrounded by double quotes'],
-            plat_is_windows
-        ))
-        test_cases.append((
-            "-o 'example file with spaces surrounded by single quotes'",
-            ['-o', 'example file with spaces surrounded by single quotes'],
-            plat_is_windows
-        ))
-        test_cases.append((
-            '-o "example with an inner {}" double quote"'.format(escape_chars[plat_is_windows]),
-            ['-o', 'example with an inner " double quote'],
-            plat_is_windows
-        ))
-        test_cases.append((
-            "-o 'example with an inner {}' single quote'".format(escape_chars[plat_is_windows]),
-            ['-o', "example with an inner ' single quote"],
-            plat_is_windows
-        ))
+        test_cases.append(
+            (
+                '-o "example file with spaces surrounded by double quotes"',
+                ["-o", "example file with spaces surrounded by double quotes"],
+                plat_is_windows,
+            )
+        )
+        test_cases.append(
+            (
+                "-o 'example file with spaces surrounded by single quotes'",
+                ["-o", "example file with spaces surrounded by single quotes"],
+                plat_is_windows,
+            )
+        )
+        test_cases.append(
+            (
+                '-o "example with an inner {}" double quote"'.format(escape_chars[plat_is_windows]),
+                ["-o", 'example with an inner " double quote'],
+                plat_is_windows,
+            )
+        )
+        test_cases.append(
+            (
+                "-o 'example with an inner {}' single quote'".format(escape_chars[plat_is_windows]),
+                ["-o", "example with an inner ' single quote"],
+                plat_is_windows,
+            )
+        )
     return test_cases
 
 
-@pytest.mark.parametrize('arg_line, expected_args, plat_is_windows', build_convert_special_cases())
+@pytest.mark.parametrize("arg_line, expected_args, plat_is_windows", build_convert_special_cases())
 def test_comment_ignoring_argument_parser_convert_special_cases(arg_line, expected_args, plat_is_windows):
     parser = arg_parsing.CommentIgnoringArgumentParser()
     parser._CommentIgnoringArgumentParser__is_windows = plat_is_windows
@@ -187,184 +182,169 @@ def test_f_comment_ignoring_argument_parser_convert_filename():
 def test_unique_store_action_first_call():
     mock_parser = MagicMock()
     mock_namespace = MagicMock(special_attribute=None)
-    action = arg_parsing.UniqueStoreAction(
-        option_strings=sentinel.option_strings,
-        dest='special_attribute'
-    )
-    action(
-        parser=mock_parser,
-        namespace=mock_namespace,
-        values=sentinel.values,
-        option_string='SPECIAL_ATTRIBUTE'
-    )
+    action = arg_parsing.UniqueStoreAction(option_strings=sentinel.option_strings, dest="special_attribute")
+    action(parser=mock_parser, namespace=mock_namespace, values=sentinel.values, option_string="SPECIAL_ATTRIBUTE")
     assert mock_namespace.special_attribute is sentinel.values
 
 
 def test_unique_store_action_second_call():
     mock_parser = MagicMock()
     mock_namespace = MagicMock(special_attribute=sentinel.attribute)
-    action = arg_parsing.UniqueStoreAction(
-        option_strings=sentinel.option_strings,
-        dest='special_attribute'
-    )
-    action(
-        parser=mock_parser,
-        namespace=mock_namespace,
-        values=sentinel.values,
-        option_string='SPECIAL_ATTRIBUTE'
-    )
+    action = arg_parsing.UniqueStoreAction(option_strings=sentinel.option_strings, dest="special_attribute")
+    action(parser=mock_parser, namespace=mock_namespace, values=sentinel.values, option_string="SPECIAL_ATTRIBUTE")
     assert mock_namespace.special_attribute is sentinel.attribute
-    mock_parser.error.assert_called_once_with('SPECIAL_ATTRIBUTE argument may not be specified more than once')
+    mock_parser.error.assert_called_once_with("SPECIAL_ATTRIBUTE argument may not be specified more than once")
 
 
 def build_expected_good_args(from_file=False):  # pylint: disable=too-many-locals
-    encrypt = '-e'
-    decrypt = '-d'
-    suppress_metadata = ' -S'
-    short_input = ' -i -'
-    long_input = ' --input -'
-    short_output = ' -o -'
-    long_output = ' --output -'
+    encrypt = "-e"
+    decrypt = "-d"
+    suppress_metadata = " -S"
+    short_input = " -i -"
+    long_input = " --input -"
+    short_output = " -o -"
+    long_output = " --output -"
     valid_io = short_input + short_output
-    mkp_1 = ' -m provider=ex_provider_1 key=ex_mk_id_1'
-    mkp_1_parsed = {'provider': 'ex_provider_1', 'key': ['ex_mk_id_1']}
-    mkp_2 = ' -m provider=ex_provider_2 key=ex_mk_id_2'
-    mkp_2_parsed = {'provider': 'ex_provider_2', 'key': ['ex_mk_id_2']}
+    mkp_1 = " -m provider=ex_provider_1 key=ex_mk_id_1"
+    mkp_1_parsed = {"provider": "ex_provider_1", "key": ["ex_mk_id_1"]}
+    mkp_2 = " -m provider=ex_provider_2 key=ex_mk_id_2"
+    mkp_2_parsed = {"provider": "ex_provider_2", "key": ["ex_mk_id_2"]}
     default_encrypt = encrypt + suppress_metadata + valid_io + mkp_1
     good_args = []
 
     # encrypt/decrypt
-    for encrypt_flag in (encrypt, '--encrypt'):
-        good_args.append((encrypt_flag + suppress_metadata + valid_io + mkp_1, 'action', 'encrypt'))
-    for decrypt_flag in (decrypt, '--decrypt'):
-        good_args.append((decrypt_flag + suppress_metadata + valid_io + mkp_1, 'action', 'decrypt'))
+    for encrypt_flag in (encrypt, "--encrypt"):
+        good_args.append((encrypt_flag + suppress_metadata + valid_io + mkp_1, "action", "encrypt"))
+    for decrypt_flag in (decrypt, "--decrypt"):
+        good_args.append((decrypt_flag + suppress_metadata + valid_io + mkp_1, "action", "decrypt"))
 
     # master key config
-    good_args.append((default_encrypt, 'master_keys', [mkp_1_parsed]))
-    good_args.append((default_encrypt + mkp_2, 'master_keys', [mkp_1_parsed, mkp_2_parsed]))
+    good_args.append((default_encrypt, "master_keys", [mkp_1_parsed]))
+    good_args.append((default_encrypt + mkp_2, "master_keys", [mkp_1_parsed, mkp_2_parsed]))
 
     # input/output
     for input_flag in (short_input, long_input):
-        good_args.append((encrypt + suppress_metadata + input_flag + short_output + mkp_1, 'input', '-'))
+        good_args.append((encrypt + suppress_metadata + input_flag + short_output + mkp_1, "input", "-"))
     for output_flag in (short_output, long_output):
-        good_args.append((encrypt + suppress_metadata + output_flag + short_input + mkp_1, 'output', '-'))
+        good_args.append((encrypt + suppress_metadata + output_flag + short_input + mkp_1, "output", "-"))
 
     # encryption context
-    good_args.append((default_encrypt, 'encryption_context', {}))
-    good_args.append((
-        default_encrypt + ' -c some=data not=secret',
-        'encryption_context',
-        {'some': 'data', 'not': 'secret'}
-    ))
+    good_args.append((default_encrypt, "encryption_context", {}))
+    good_args.append(
+        (default_encrypt + " -c some=data not=secret", "encryption_context", {"some": "data", "not": "secret"})
+    )
     if from_file:
-        good_args.append((
-            default_encrypt + ' -c "key with a space=value with a space"',
-            'encryption_context',
-            {'key with a space': 'value with a space'}
-        ))
+        good_args.append(
+            (
+                default_encrypt + ' -c "key with a space=value with a space"',
+                "encryption_context",
+                {"key with a space": "value with a space"},
+            )
+        )
     else:
-        good_args.append((
-            default_encrypt + ' -c "key with a space=value with a space"',
-            'encryption_context',
-            {'key with a space': 'value with a space'}
-        ))
+        good_args.append(
+            (
+                default_encrypt + ' -c "key with a space=value with a space"',
+                "encryption_context",
+                {"key with a space": "value with a space"},
+            )
+        )
 
     # algorithm
-    algorithm_name = 'AES_128_GCM_IV12_TAG16'
-    good_args.append((default_encrypt, 'algorithm', None))
-    good_args.append((default_encrypt + ' --algorithm ' + algorithm_name, 'algorithm', algorithm_name))
+    algorithm_name = "AES_128_GCM_IV12_TAG16"
+    good_args.append((default_encrypt, "algorithm", None))
+    good_args.append((default_encrypt + " --algorithm " + algorithm_name, "algorithm", algorithm_name))
 
     # frame length
-    good_args.append((default_encrypt, 'frame_length', None))
-    good_args.append((default_encrypt + ' --frame-length 99', 'frame_length', 99))
+    good_args.append((default_encrypt, "frame_length", None))
+    good_args.append((default_encrypt + " --frame-length 99", "frame_length", 99))
 
     # max length
-    good_args.append((default_encrypt, 'max_length', None))
-    good_args.append((default_encrypt + ' --max-length 99', 'max_length', 99))
+    good_args.append((default_encrypt, "max_length", None))
+    good_args.append((default_encrypt + " --max-length 99", "max_length", 99))
 
     # interactive
-    good_args.append((default_encrypt, 'interactive', False))
-    good_args.append((default_encrypt + ' --interactive', 'interactive', True))
+    good_args.append((default_encrypt, "interactive", False))
+    good_args.append((default_encrypt + " --interactive", "interactive", True))
 
     # no-overwrite
-    good_args.append((default_encrypt, 'no_overwrite', False))
-    good_args.append((default_encrypt + ' --no-overwrite', 'no_overwrite', True))
+    good_args.append((default_encrypt, "no_overwrite", False))
+    good_args.append((default_encrypt + " --no-overwrite", "no_overwrite", True))
 
     # suffix
-    good_args.append((default_encrypt + ' --suffix .MY_SPECIAL_SUFFIX', 'suffix', '.MY_SPECIAL_SUFFIX'))
-    good_args.append((default_encrypt + ' --suffix', 'suffix', ''))
+    good_args.append((default_encrypt + " --suffix .MY_SPECIAL_SUFFIX", "suffix", ".MY_SPECIAL_SUFFIX"))
+    good_args.append((default_encrypt + " --suffix", "suffix", ""))
 
     # recursive
-    good_args.append((default_encrypt, 'recursive', False))
-    for recursive_flag in (' -r', ' -R', ' --recursive'):
-        good_args.append((default_encrypt + recursive_flag, 'recursive', True))
+    good_args.append((default_encrypt, "recursive", False))
+    for recursive_flag in (" -r", " -R", " --recursive"):
+        good_args.append((default_encrypt + recursive_flag, "recursive", True))
 
     # logging verbosity
-    good_args.append((default_encrypt, 'verbosity', None))
+    good_args.append((default_encrypt, "verbosity", None))
     for count in (1, 2, 3, 4):
-        good_args.append((default_encrypt + ' -' + 'v' * count, 'verbosity', count))
+        good_args.append((default_encrypt + " -" + "v" * count, "verbosity", count))
 
     # metadata output
-    good_args.append((default_encrypt, 'metadata_output', metadata.MetadataWriter(suppress_output=True)()))
-    good_args.append((
-        encrypt + valid_io + mkp_1 + ' --metadata-output -',
-        'metadata_output',
-        metadata.MetadataWriter(suppress_output=False)(output_file='-')
-    ))
+    good_args.append((default_encrypt, "metadata_output", metadata.MetadataWriter(suppress_output=True)()))
+    good_args.append(
+        (
+            encrypt + valid_io + mkp_1 + " --metadata-output -",
+            "metadata_output",
+            metadata.MetadataWriter(suppress_output=False)(output_file="-"),
+        )
+    )
 
     return good_args
 
 
-@pytest.mark.parametrize('argstring, attribute, value', build_expected_good_args())
+@pytest.mark.parametrize("argstring, attribute, value", build_expected_good_args())
 def test_parser_from_shell(argstring, attribute, value):
     parsed = arg_parsing.parse_args(shlex.split(argstring))
     assert getattr(parsed, attribute) == value
 
 
-@pytest.mark.parametrize('argstring, attribute, value', build_expected_good_args(from_file=True))
+@pytest.mark.parametrize("argstring, attribute, value", build_expected_good_args(from_file=True))
 def test_parser_fromfile(tmpdir, argstring, attribute, value):
-    argfile = tmpdir.join('argfile')
+    argfile = tmpdir.join("argfile")
     argfile.write(argstring)
-    parsed = arg_parsing.parse_args(['@{}'.format(argfile)])
+    parsed = arg_parsing.parse_args(["@{}".format(argfile)])
     assert getattr(parsed, attribute) == value
 
 
 def build_bad_io_arguments():
     return [
-        '-d -S -o - -m provider=ex_provider key=ex_mk_id',
-        '-d -S -i - -m provider=ex_provider key=ex_mk_id',
-        '-d -S -i - -o - --required-encryption-context-keys asd asdfa'
+        "-d -S -o - -m provider=ex_provider key=ex_mk_id",
+        "-d -S -i - -m provider=ex_provider key=ex_mk_id",
+        "-d -S -i - -o - --required-encryption-context-keys asd asdfa",
     ]
 
 
 def build_bad_multiple_arguments():
-    prefix = '-d -S -i - -o -'
+    prefix = "-d -S -i - -o -"
     protected_arguments = [
-        ' --caching key=value',
-        ' --input -',
-        ' --output -',
-        ' --encryption-context key=value',
-        ' --algorithm ALGORITHM',
-        ' --frame-length 256',
-        ' --max-length 1024',
-        ' --suffix .MY_SPECIAL_SUFFIX'
+        " --caching key=value",
+        " --input -",
+        " --output -",
+        " --encryption-context key=value",
+        " --algorithm ALGORITHM",
+        " --frame-length 256",
+        " --max-length 1024",
+        " --suffix .MY_SPECIAL_SUFFIX",
     ]
-    return [
-        prefix + arg + arg
-        for arg in protected_arguments
-    ]
+    return [prefix + arg + arg for arg in protected_arguments]
 
 
 def build_bad_dummy_arguments():
     parser = arg_parsing._build_parser()
     dummy_arguments = parser._CommentIgnoringArgumentParser__dummy_arguments
     bad_commands = []
-    safe_pattern = '-d -S -i - -o - {arg}'
+    safe_pattern = "-d -S -i - -o - {arg}"
     partial_patterns = {
-        '-decrypt': '{arg} -i - -o - -S',
-        '-encrypt': '{arg} -i - -o - -S',
-        '-input': '-d {arg} - -o - -S',
-        '-output': '-d -i - {arg} - -S',
+        "-decrypt": "{arg} -i - -o - -S",
+        "-encrypt": "{arg} -i - -o - -S",
+        "-input": "-d {arg} - -o - -S",
+        "-output": "-d -i - {arg} - -S",
     }
     for arg in dummy_arguments:
         pattern = partial_patterns.get(arg, safe_pattern)
@@ -384,8 +364,7 @@ def test_dummy_arguments_covered():
 
 
 @pytest.mark.parametrize(
-    'args',
-    build_bad_io_arguments() + build_bad_multiple_arguments() + build_bad_dummy_arguments()
+    "args", build_bad_io_arguments() + build_bad_multiple_arguments() + build_bad_dummy_arguments()
 )
 def test_parse_args_fail(args):
     with pytest.raises(SystemExit) as excinfo:
@@ -394,27 +373,20 @@ def test_parse_args_fail(args):
     assert excinfo.value.args == (2,)
 
 
-@pytest.mark.parametrize('source, expected', (
+@pytest.mark.parametrize(
+    "source, expected",
     (
-        ['a=b', 'c=d', 'e=f'],
-        {'a': ['b'], 'c': ['d'], 'e': ['f']}
+        (["a=b", "c=d", "e=f"], {"a": ["b"], "c": ["d"], "e": ["f"]}),
+        (["a=b", "b=c", "b=d"], {"a": ["b"], "b": ["c", "d"]}),
     ),
-    (
-        ['a=b', 'b=c', 'b=d'],
-        {'a': ['b'], 'b': ['c', 'd']}
-    )
-))
+)
 def test_parse_kwargs_good(source, expected):
     test = arg_parsing._parse_kwargs(source)
 
     assert test == expected
 
 
-@pytest.mark.parametrize('bad_arg', (
-    'key_without_value',
-    'key_with_empty_value=',
-    '=value_with_empty_key'
-))
+@pytest.mark.parametrize("bad_arg", ("key_without_value", "key_with_empty_value=", "=value_with_empty_key"))
 def test_parse_kwargs_fail(bad_arg):
     with pytest.raises(ParameterParseError) as excinfo:
         arg_parsing._parse_kwargs([bad_arg])
@@ -423,8 +395,8 @@ def test_parse_kwargs_fail(bad_arg):
 
 
 def test_collapse_config():
-    source = {'a': ['b'], 'c': ['d'], 'e': ['f']}
-    expected = {'a': 'b', 'c': 'd', 'e': 'f'}
+    source = {"a": ["b"], "c": ["d"], "e": ["f"]}
+    expected = {"a": "b", "c": "d", "e": "f"}
 
     test = arg_parsing._collapse_config(source)
 
@@ -432,8 +404,8 @@ def test_collapse_config():
 
 
 def test_parse_and_collapse_config():
-    source = ['key1=value1', 'key2=value2', 'key3=value3']
-    expected = {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}
+    source = ["key1=value1", "key2=value2", "key3=value3"]
+    expected = {"key1": "value1", "key2": "value2", "key3": "value3"}
 
     test = arg_parsing._parse_and_collapse_config(source)
 
@@ -441,8 +413,8 @@ def test_parse_and_collapse_config():
 
 
 def test_process_caching_config():
-    source = ['capacity=3', 'max_messages_encrypted=55', 'max_bytes_encrypted=8', 'max_age=32']
-    expected = {'capacity': 3, 'max_messages_encrypted': 55, 'max_bytes_encrypted': 8, 'max_age': 32.0}
+    source = ["capacity=3", "max_messages_encrypted=55", "max_bytes_encrypted=8", "max_age=32"]
+    expected = {"capacity": 3, "max_messages_encrypted": 55, "max_bytes_encrypted": 8, "max_age": 32.0}
 
     test = arg_parsing._process_caching_config(source)
 
@@ -450,11 +422,7 @@ def test_process_caching_config():
 
 
 def test_process_caching_config_bad_key():
-    source = [
-        'capacity=3',
-        'max_age=32',
-        'asdifhja9woiefhjuaowiefjoawiuehjc9awehf=fjw28304uq20498gfij83w0erifju'
-    ]
+    source = ["capacity=3", "max_age=32", "asdifhja9woiefhjuaowiefjoawiuehjc9awehf=fjw28304uq20498gfij83w0erifju"]
 
     with pytest.raises(ParameterParseError) as excinfo:
         arg_parsing._process_caching_config(source)
@@ -462,10 +430,13 @@ def test_process_caching_config_bad_key():
     excinfo.match(r'Invalid caching configuration key: "asdifhja9woiefhjuaowiefjoawiuehjc9awehf"')
 
 
-@pytest.mark.parametrize('source', (
-    ['max_messages_encrypted=55', 'max_bytes_encrypted=8', 'max_age=32'],  # no caopacity
-    ['capacity=3', 'max_messages_encrypted=55', 'max_bytes_encrypted=8']  # no max_age
-))
+@pytest.mark.parametrize(
+    "source",
+    (
+        ["max_messages_encrypted=55", "max_bytes_encrypted=8", "max_age=32"],  # no caopacity
+        ["capacity=3", "max_messages_encrypted=55", "max_bytes_encrypted=8"],  # no max_age
+    ),
+)
 def test_process_caching_config_required_parameters_missing(source):
     with pytest.raises(ParameterParseError) as excinfo:
         arg_parsing._process_caching_config(source)
@@ -474,43 +445,35 @@ def test_process_caching_config_required_parameters_missing(source):
 
 
 KEY_PROVIDER_CONFIGS = [
+    ([["provider=ex_provider", "key=ex_key"]], "encrypt", [{"provider": "ex_provider", "key": ["ex_key"]}]),
     (
-        [['provider=ex_provider', 'key=ex_key']],
-        'encrypt',
-        [{'provider': 'ex_provider', 'key': ['ex_key']}]
+        [["provider=ex_provider", "key=ex_key_1", "key=ex_key_2"]],
+        "encrypt",
+        [{"provider": "ex_provider", "key": ["ex_key_1", "ex_key_2"]}],
     ),
     (
-        [['provider=ex_provider', 'key=ex_key_1', 'key=ex_key_2']],
-        'encrypt',
-        [{'provider': 'ex_provider', 'key': ['ex_key_1', 'ex_key_2']}]
+        [["provider=ex_provider", "key=ex_key_1", "key=ex_key_2", "a=b", "asdf=4"]],
+        "encrypt",
+        [{"provider": "ex_provider", "key": ["ex_key_1", "ex_key_2"], "a": ["b"], "asdf": ["4"]}],
     ),
-    (
-        [['provider=ex_provider', 'key=ex_key_1', 'key=ex_key_2', 'a=b', 'asdf=4']],
-        'encrypt',
-        [{'provider': 'ex_provider', 'key': ['ex_key_1', 'ex_key_2'], 'a': ['b'], 'asdf': ['4']}]
-    )
 ]
-ALL_CONFIG = (
-    [i[0][0] for i in KEY_PROVIDER_CONFIGS],
-    'encrypt',
-    [i[-1][0] for i in KEY_PROVIDER_CONFIGS]
-)
+ALL_CONFIG = ([i[0][0] for i in KEY_PROVIDER_CONFIGS], "encrypt", [i[-1][0] for i in KEY_PROVIDER_CONFIGS])
 KEY_PROVIDER_CONFIGS.append(ALL_CONFIG)
-KEY_PROVIDER_CONFIGS.append((None, 'decrypt', [{'provider': identifiers.DEFAULT_MASTER_KEY_PROVIDER, 'key': []}]))
-KEY_PROVIDER_CONFIGS.append(([['provider=aws-kms']], 'decrypt', [{'provider': 'aws-kms', 'key': []}]))
-KEY_PROVIDER_CONFIGS.append((
-    [['provider=' + identifiers.DEFAULT_MASTER_KEY_PROVIDER]],
-    'decrypt',
-    [{'provider': identifiers.DEFAULT_MASTER_KEY_PROVIDER, 'key': []}]
-))
-KEY_PROVIDER_CONFIGS.append((
-    [['key=ex_key_1']],
-    'encrypt',
-    [{'provider': identifiers.DEFAULT_MASTER_KEY_PROVIDER, 'key': ['ex_key_1']}]
-))
+KEY_PROVIDER_CONFIGS.append((None, "decrypt", [{"provider": identifiers.DEFAULT_MASTER_KEY_PROVIDER, "key": []}]))
+KEY_PROVIDER_CONFIGS.append(([["provider=aws-kms"]], "decrypt", [{"provider": "aws-kms", "key": []}]))
+KEY_PROVIDER_CONFIGS.append(
+    (
+        [["provider=" + identifiers.DEFAULT_MASTER_KEY_PROVIDER]],
+        "decrypt",
+        [{"provider": identifiers.DEFAULT_MASTER_KEY_PROVIDER, "key": []}],
+    )
+)
+KEY_PROVIDER_CONFIGS.append(
+    ([["key=ex_key_1"]], "encrypt", [{"provider": identifiers.DEFAULT_MASTER_KEY_PROVIDER, "key": ["ex_key_1"]}])
+)
 
 
-@pytest.mark.parametrize('source, action, expected', KEY_PROVIDER_CONFIGS)
+@pytest.mark.parametrize("source, action, expected", KEY_PROVIDER_CONFIGS)
 def test_process_master_key_provider_configs(source, action, expected):
     test = arg_parsing._process_master_key_provider_configs(source, action)
 
@@ -519,45 +482,44 @@ def test_process_master_key_provider_configs(source, action, expected):
 
 def test_process_master_key_provider_configs_no_provider_on_encrypt():
     with pytest.raises(ParameterParseError) as excinfo:
-        arg_parsing._process_master_key_provider_configs(None, 'encrypt')
+        arg_parsing._process_master_key_provider_configs(None, "encrypt")
 
-    excinfo.match(r'No master key provider configuration found.')
+    excinfo.match(r"No master key provider configuration found.")
 
 
 def test_process_master_key_provider_configs_not_exactly_one_provider():
     with pytest.raises(ParameterParseError) as excinfo:
         arg_parsing._process_master_key_provider_configs(
-            [['provider=a', 'provider=b', 'key=ex_key_1', 'key=ex_key_2']],
-            'encrypt'
+            [["provider=a", "provider=b", "key=ex_key_1", "key=ex_key_2"]], "encrypt"
         )
 
     excinfo.match(r'Exactly one "provider" must be provided for each master key provider configuration. 2 provided')
 
 
-@pytest.mark.parametrize('provider', ('aws-kms', identifiers.DEFAULT_MASTER_KEY_PROVIDER))
+@pytest.mark.parametrize("provider", ("aws-kms", identifiers.DEFAULT_MASTER_KEY_PROVIDER))
 def test_master_key_specified_on_decrypt_for_kms(provider):
-    source = [['provider=' + provider, 'key=example']]
+    source = [["provider=" + provider, "key=example"]]
 
     with pytest.raises(ParameterParseError) as excinfo:
-        arg_parsing._process_master_key_provider_configs(source, 'decrypt')
+        arg_parsing._process_master_key_provider_configs(source, "decrypt")
 
-    excinfo.match(r'Exact master keys cannot be specified for aws-kms master key provider on decrypt.')
+    excinfo.match(r"Exact master keys cannot be specified for aws-kms master key provider on decrypt.")
 
 
 def test_process_master_key_provider_configs_no_keys():
-    source = [['provider=ex_provider', 'aaa=sadfa']]
+    source = [["provider=ex_provider", "aaa=sadfa"]]
 
     with pytest.raises(ParameterParseError) as excinfo:
-        arg_parsing._process_master_key_provider_configs(source, 'encrypt')
+        arg_parsing._process_master_key_provider_configs(source, "encrypt")
 
     excinfo.match(r'At least one "key" must be provided for each master key provider configuration')
 
 
 def test_parse_args(
-        patch_build_parser,
-        patch_process_master_key_provider_configs,
-        patch_process_encryption_context,
-        patch_process_caching_config
+    patch_build_parser,
+    patch_process_master_key_provider_configs,
+    patch_process_encryption_context,
+    patch_process_caching_config,
 ):
     mock_parsed_args = MagicMock(
         master_keys=sentinel.raw_keys,
@@ -566,7 +528,7 @@ def test_parse_args(
         caching=sentinel.raw_caching,
         action=sentinel.action,
         version=False,
-        dummy_redirect=None
+        dummy_redirect=None,
     )
     patch_build_parser.return_value.parse_args.return_value = mock_parsed_args
     test = arg_parsing.parse_args(sentinel.raw_args)
@@ -578,7 +540,7 @@ def test_parse_args(
     patch_process_encryption_context.assert_called_once_with(
         action=sentinel.action,
         raw_encryption_context=sentinel.raw_encryption_context,
-        raw_required_encryption_context_keys=None
+        raw_required_encryption_context_keys=None,
     )
     assert test.encryption_context is sentinel.encryption_context
     assert test.required_encryption_context_keys is sentinel.required_keys
@@ -588,10 +550,10 @@ def test_parse_args(
 
 
 def test_parse_args_dummy_redirect(
-        patch_build_parser,
-        patch_process_master_key_provider_configs,
-        patch_process_encryption_context,
-        patch_process_caching_config
+    patch_build_parser,
+    patch_process_master_key_provider_configs,
+    patch_process_encryption_context,
+    patch_process_caching_config,
 ):
     mock_parsed_args = MagicMock(
         master_keys=sentinel.raw_keys,
@@ -599,7 +561,7 @@ def test_parse_args_dummy_redirect(
         caching=sentinel.raw_caching,
         action=sentinel.action,
         version=False,
-        dummy_redirect='-invalid-argument'
+        dummy_redirect="-invalid-argument",
     )
     patch_build_parser.return_value.parse_args.return_value = mock_parsed_args
     arg_parsing.parse_args(sentinel.raw_args)
@@ -610,10 +572,10 @@ def test_parse_args_dummy_redirect(
 
 
 def test_parse_args_no_caching_config(
-        patch_build_parser,
-        patch_process_master_key_provider_configs,
-        patch_process_encryption_context,
-        patch_process_caching_config
+    patch_build_parser,
+    patch_process_master_key_provider_configs,
+    patch_process_encryption_context,
+    patch_process_caching_config,
 ):
     patch_build_parser.return_value.parse_args.return_value = MagicMock(caching=None)
     test = arg_parsing.parse_args()
@@ -623,15 +585,13 @@ def test_parse_args_no_caching_config(
 
 
 def test_parse_args_error_raised_in_post_processing(
-        patch_build_parser,
-        patch_process_master_key_provider_configs,
-        patch_process_encryption_context,
-        patch_process_caching_config
+    patch_build_parser,
+    patch_process_master_key_provider_configs,
+    patch_process_encryption_context,
+    patch_process_caching_config,
 ):
     patch_build_parser.return_value.parse_args.return_value = MagicMock(
-        version=False,
-        dummy_redirect=None,
-        required_encryption_context_keys=None
+        version=False, dummy_redirect=None, required_encryption_context_keys=None
     )
     patch_process_caching_config.side_effect = ParameterParseError
 
@@ -641,46 +601,40 @@ def test_parse_args_error_raised_in_post_processing(
 
 
 @pytest.mark.parametrize(
-    'action, raw_encryption_context, raw_required_keys, expected_encryption_context, expected_required_keys',
+    "action, raw_encryption_context, raw_required_keys, expected_encryption_context, expected_required_keys",
     (
-        ('encrypt', None, None, {}, []),
-        ('decrypt', None, None, {}, []),
-        ('encrypt', ['encryption=context', 'with=values'], None, {'encryption': 'context', 'with': 'values'}, []),
-        ('decrypt', ['encryption=context', 'with=values'], None, {'encryption': 'context', 'with': 'values'}, []),
+        ("encrypt", None, None, {}, []),
+        ("decrypt", None, None, {}, []),
+        ("encrypt", ["encryption=context", "with=values"], None, {"encryption": "context", "with": "values"}, []),
+        ("decrypt", ["encryption=context", "with=values"], None, {"encryption": "context", "with": "values"}, []),
         (
-            'encrypt',
-            ['encryption=context', 'with=values'],
-            ['key_1', 'key_2'],
-            {'encryption': 'context', 'with': 'values'},
-            ['key_1', 'key_2']
+            "encrypt",
+            ["encryption=context", "with=values"],
+            ["key_1", "key_2"],
+            {"encryption": "context", "with": "values"},
+            ["key_1", "key_2"],
         ),
         (
-            'decrypt',
-            ['encryption=context', 'with=values'],
-            ['key_1', 'key_2'],
-            {'encryption': 'context', 'with': 'values'},
-            ['key_1', 'key_2']
+            "decrypt",
+            ["encryption=context", "with=values"],
+            ["key_1", "key_2"],
+            {"encryption": "context", "with": "values"},
+            ["key_1", "key_2"],
         ),
         (
-            'decrypt',
-            ['encryption=context', 'with=values', 'key_3'],
-            ['key_1', 'key_2'],
-            {'encryption': 'context', 'with': 'values'},
-            ['key_1', 'key_2', 'key_3']
+            "decrypt",
+            ["encryption=context", "with=values", "key_3"],
+            ["key_1", "key_2"],
+            {"encryption": "context", "with": "values"},
+            ["key_1", "key_2", "key_3"],
         ),
-    )
+    ),
 )
 def test_process_encryption_context(
-        action,
-        raw_encryption_context,
-        raw_required_keys,
-        expected_encryption_context,
-        expected_required_keys
+    action, raw_encryption_context, raw_required_keys, expected_encryption_context, expected_required_keys
 ):
     test_encryption_context, test_required_keys = arg_parsing._process_encryption_context(
-        action,
-        raw_encryption_context,
-        raw_required_keys
+        action, raw_encryption_context, raw_required_keys
     )
 
     assert test_encryption_context == expected_encryption_context
@@ -690,7 +644,7 @@ def test_process_encryption_context(
 def test_process_encryption_context_encrypt_required_key_fail():
     with pytest.raises(ParameterParseError):
         arg_parsing._process_encryption_context(
-            action='encrypt',
-            raw_encryption_context=['encryption=context', 'with=values', 'key_3'],
-            raw_required_encryption_context_keys=['key_1', 'key_2']
+            action="encrypt",
+            raw_encryption_context=["encryption=context", "with=values", "key_3"],
+            raw_required_encryption_context_keys=["key_1", "key_2"],
         )

--- a/test/unit/test_arg_parsing.py
+++ b/test/unit/test_arg_parsing.py
@@ -16,8 +16,8 @@ import platform
 import shlex
 
 import aws_encryption_sdk
-from mock import MagicMock, sentinel
 import pytest
+from mock import MagicMock, sentinel
 from pytest_mock import mocker  # noqa pylint: disable=unused-import
 
 import aws_encryption_sdk_cli

--- a/test/unit/test_aws_encryption_sdk_cli.py
+++ b/test/unit/test_aws_encryption_sdk_cli.py
@@ -16,14 +16,15 @@ import os
 import shlex
 
 import aws_encryption_sdk
-from mock import ANY, call, MagicMock, sentinel
 import pytest
 import six
+from mock import ANY, MagicMock, call, sentinel
 
 import aws_encryption_sdk_cli
 from aws_encryption_sdk_cli.exceptions import AWSEncryptionSDKCLIError, BadUserArgumentError
-from aws_encryption_sdk_cli.internal.logging_utils import _KMSKeyRedactingFormatter, FORMAT_STRING
+from aws_encryption_sdk_cli.internal.logging_utils import FORMAT_STRING, _KMSKeyRedactingFormatter
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
+
 from .unit_test_utils import is_windows
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]

--- a/test/unit/test_aws_encryption_sdk_cli.py
+++ b/test/unit/test_aws_encryption_sdk_cli.py
@@ -32,18 +32,18 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 @pytest.fixture
 def patch_process_cli_request(mocker):
-    mocker.patch.object(aws_encryption_sdk_cli, 'process_cli_request')
+    mocker.patch.object(aws_encryption_sdk_cli, "process_cli_request")
     return aws_encryption_sdk_cli.process_cli_request
 
 
 @pytest.fixture
 def patch_iohandler(mocker):
-    mocker.patch.object(aws_encryption_sdk_cli, 'IOHandler')
+    mocker.patch.object(aws_encryption_sdk_cli, "IOHandler")
     return aws_encryption_sdk_cli.IOHandler
 
 
 def test_catch_bad_destination_requests_stdout():
-    aws_encryption_sdk_cli._catch_bad_destination_requests('-')
+    aws_encryption_sdk_cli._catch_bad_destination_requests("-")
 
 
 def test_catch_bad_destination_requests_dir(tmpdir):
@@ -51,15 +51,15 @@ def test_catch_bad_destination_requests_dir(tmpdir):
 
 
 def test_catch_bad_destination_requests_file(tmpdir):
-    destination = tmpdir.join('dir1', 'dir2', 'file')
+    destination = tmpdir.join("dir1", "dir2", "file")
     with pytest.raises(BadUserArgumentError) as excinfo:
         aws_encryption_sdk_cli._catch_bad_destination_requests(str(destination))
 
-    assert excinfo.match(r'If destination is a file, the immediate parent directory must already exist.')
+    assert excinfo.match(r"If destination is a file, the immediate parent directory must already exist.")
 
 
 def test_catch_bad_stdin_stdout_requests_same_pipe():
-    aws_encryption_sdk_cli._catch_bad_stdin_stdout_requests('-', '-')
+    aws_encryption_sdk_cli._catch_bad_stdin_stdout_requests("-", "-")
 
 
 def build_same_files_and_dirs(tmpdir, source_is_symlink, dest_is_symlink, use_files):
@@ -70,11 +70,11 @@ def build_same_files_and_dirs(tmpdir, source_is_symlink, dest_is_symlink, use_fi
     :param bool use_files: Should files be created (if False, directories are used instead)
     """
     if use_files:
-        real = tmpdir.join('real')
-        real.write('some data')
+        real = tmpdir.join("real")
+        real.write("some data")
     else:
-        real = tmpdir.mkdir('real')
-    link = tmpdir.join('link')
+        real = tmpdir.mkdir("real")
+    link = tmpdir.join("link")
 
     if source_is_symlink or dest_is_symlink:
         os.symlink(str(real), str(link))
@@ -89,93 +89,86 @@ def build_same_files_and_dirs(tmpdir, source_is_symlink, dest_is_symlink, use_fi
 
 def build_same_file_and_dir_test_cases():
     if is_windows():
-        return [
-            (False, False, True),
-            (False, False, False)
-        ]
+        return [(False, False, True), (False, False, False)]
 
     test_cases = []
     for use_files in (True, False):
-        test_cases.extend([
-            (False, False, use_files),
-            (True, False, use_files),
-            (False, True, use_files)
-        ])
+        test_cases.extend([(False, False, use_files), (True, False, use_files), (False, True, use_files)])
     return test_cases
 
 
-@pytest.mark.parametrize('source_is_symlink, dest_is_symlink, use_files', build_same_file_and_dir_test_cases())
+@pytest.mark.parametrize("source_is_symlink, dest_is_symlink, use_files", build_same_file_and_dir_test_cases())
 def test_catch_bad_stdin_stdout_requests_source_is_dest(tmpdir, source_is_symlink, dest_is_symlink, use_files):
     source, dest = build_same_files_and_dirs(tmpdir, source_is_symlink, dest_is_symlink, use_files)
 
     with pytest.raises(BadUserArgumentError) as excinfo:
         aws_encryption_sdk_cli._catch_bad_stdin_stdout_requests(source, dest)
 
-    excinfo.match(r'Destination and source cannot be the same')
+    excinfo.match(r"Destination and source cannot be the same")
 
 
 def test_catch_bad_stdin_stdout_requests_stdin_dir(tmpdir):
     with pytest.raises(BadUserArgumentError) as excinfo:
-        aws_encryption_sdk_cli._catch_bad_stdin_stdout_requests('-', str(tmpdir))
+        aws_encryption_sdk_cli._catch_bad_stdin_stdout_requests("-", str(tmpdir))
 
-    excinfo.match(r'Destination may not be a directory when source is stdin')
+    excinfo.match(r"Destination may not be a directory when source is stdin")
 
 
 def test_catch_bad_file_and_directory_requests_multiple_source_nondir_destination(tmpdir):
-    a = tmpdir.join('a')
-    a.write('asdf')
-    b = tmpdir.join('b')
-    b.write('asdf')
+    a = tmpdir.join("a")
+    a.write("asdf")
+    b = tmpdir.join("b")
+    b.write("asdf")
 
     with pytest.raises(BadUserArgumentError) as excinfo:
-        aws_encryption_sdk_cli._catch_bad_file_and_directory_requests((str(a), str(b)), str(tmpdir.join('c')))
+        aws_encryption_sdk_cli._catch_bad_file_and_directory_requests((str(a), str(b)), str(tmpdir.join("c")))
 
-    excinfo.match(r'If operating on multiple sources, destination must be an existing directory')
+    excinfo.match(r"If operating on multiple sources, destination must be an existing directory")
 
 
 def test_catch_bad_file_and_directory_requests_contains_dir(tmpdir):
-    b = tmpdir.mkdir('b')
+    b = tmpdir.mkdir("b")
 
     with pytest.raises(BadUserArgumentError) as excinfo:
-        aws_encryption_sdk_cli._catch_bad_file_and_directory_requests((str(b),), str(tmpdir.join('c')))
+        aws_encryption_sdk_cli._catch_bad_file_and_directory_requests((str(b),), str(tmpdir.join("c")))
 
-    excinfo.match(r'If operating on a source directory, destination must be an existing directory')
+    excinfo.match(r"If operating on a source directory, destination must be an existing directory")
 
 
 def test_catch_bad_metadata_file_requests_metadata_and_output_are_stdout():
-    metadata_writer = MetadataWriter(suppress_output=False)(output_file='-')
+    metadata_writer = MetadataWriter(suppress_output=False)(output_file="-")
 
     with pytest.raises(BadUserArgumentError) as excinfo:
-        aws_encryption_sdk_cli._catch_bad_metadata_file_requests(metadata_writer, '-', '-')
+        aws_encryption_sdk_cli._catch_bad_metadata_file_requests(metadata_writer, "-", "-")
 
-    excinfo.match(r'Metadata output cannot be stdout when output is stdout')
+    excinfo.match(r"Metadata output cannot be stdout when output is stdout")
 
 
 def test_catch_bad_metadata_file_requests_metadata_metadata_is_stdout_but_output_is_not():
-    metadata_writer = MetadataWriter(suppress_output=False)(output_file='-')
+    metadata_writer = MetadataWriter(suppress_output=False)(output_file="-")
 
-    aws_encryption_sdk_cli._catch_bad_metadata_file_requests(metadata_writer, 'not-std-in', 'not-std-out')
+    aws_encryption_sdk_cli._catch_bad_metadata_file_requests(metadata_writer, "not-std-in", "not-std-out")
 
 
 def test_catch_bad_metadata_file_requests_metadata_is_dir(tmpdir):
     metadata_writer = MetadataWriter(suppress_output=False)(output_file=str(tmpdir))
 
     with pytest.raises(BadUserArgumentError) as excinfo:
-        aws_encryption_sdk_cli._catch_bad_metadata_file_requests(metadata_writer, '-', '-')
+        aws_encryption_sdk_cli._catch_bad_metadata_file_requests(metadata_writer, "-", "-")
 
-    excinfo.match(r'Metadata output cannot be a directory')
+    excinfo.match(r"Metadata output cannot be a directory")
 
 
 def test_catch_bad_metadata_file_requests_metadata_is_not_stdout_but_input_and_output_are_pipes(tmpdir):
-    metadata_writer = MetadataWriter(suppress_output=False)(output_file=str(tmpdir.join('metadata')))
+    metadata_writer = MetadataWriter(suppress_output=False)(output_file=str(tmpdir.join("metadata")))
 
-    aws_encryption_sdk_cli._catch_bad_metadata_file_requests(metadata_writer, '-', '-')
+    aws_encryption_sdk_cli._catch_bad_metadata_file_requests(metadata_writer, "-", "-")
 
 
 def test_catch_bad_metadata_file_requests_metadata_all_are_unique_files(tmpdir):
-    source = tmpdir.join('source')
-    metadata_file = tmpdir.join('metadata')
-    destination = tmpdir.join('destination')
+    source = tmpdir.join("source")
+    metadata_file = tmpdir.join("metadata")
+    destination = tmpdir.join("destination")
 
     metadata_writer = MetadataWriter(suppress_output=False)(output_file=str(metadata_file))
 
@@ -183,32 +176,23 @@ def test_catch_bad_metadata_file_requests_metadata_all_are_unique_files(tmpdir):
 
 
 def build_bad_metadata_file_requests():
-    bad_requests = [
-        (False, False, 'source'),
-        (False, False, 'dest')
-    ]
+    bad_requests = [(False, False, "source"), (False, False, "dest")]
     if not is_windows():
-        bad_requests.extend([
-            (True, False, 'source'),
-            (False, True, 'source'),
-            (True, False, 'dest'),
-            (False, True, 'dest')
-        ])
+        bad_requests.extend(
+            [(True, False, "source"), (False, True, "source"), (True, False, "dest"), (False, True, "dest")]
+        )
     return bad_requests
 
 
-@pytest.mark.parametrize('metadata_is_symlink, match_is_symlink, match', build_bad_metadata_file_requests())
+@pytest.mark.parametrize("metadata_is_symlink, match_is_symlink, match", build_bad_metadata_file_requests())
 def test_catch_bad_metadata_file_requests_metadata_is_source_or_dest(
-        tmpdir,
-        metadata_is_symlink,
-        match_is_symlink,
-        match
+    tmpdir, metadata_is_symlink, match_is_symlink, match
 ):
-    if match == 'source':
+    if match == "source":
         source, metadata_file = build_same_files_and_dirs(tmpdir, metadata_is_symlink, match_is_symlink, True)
-        destination = tmpdir.join('destination')
+        destination = tmpdir.join("destination")
     else:
-        source = tmpdir.join('source')
+        source = tmpdir.join("source")
         destination, metadata_file = build_same_files_and_dirs(tmpdir, metadata_is_symlink, match_is_symlink, True)
 
     metadata_writer = MetadataWriter(suppress_output=False)(output_file=str(metadata_file))
@@ -216,47 +200,41 @@ def test_catch_bad_metadata_file_requests_metadata_is_source_or_dest(
     with pytest.raises(BadUserArgumentError) as excinfo:
         aws_encryption_sdk_cli._catch_bad_metadata_file_requests(metadata_writer, str(source), str(destination))
 
-    excinfo.match(r'Metadata output file cannot be the input or output')
+    excinfo.match(r"Metadata output file cannot be the input or output")
 
 
-@pytest.mark.parametrize('match', ('input', 'output'))
+@pytest.mark.parametrize("match", ("input", "output"))
 def test_catch_bad_metadata_file_requests_metadata_in_source_or_dest_dir(tmpdir, match):
-    source = tmpdir.mkdir('source')
-    destination = tmpdir.mkdir('destination')
-    if match == 'input':
-        metadata_file = source.join('metadata')
+    source = tmpdir.mkdir("source")
+    destination = tmpdir.mkdir("destination")
+    if match == "input":
+        metadata_file = source.join("metadata")
     else:
-        metadata_file = destination.join('metadata')
+        metadata_file = destination.join("metadata")
 
     metadata_writer = MetadataWriter(suppress_output=False)(output_file=str(metadata_file))
 
     with pytest.raises(BadUserArgumentError) as excinfo:
         aws_encryption_sdk_cli._catch_bad_metadata_file_requests(metadata_writer, str(source), str(destination))
 
-    excinfo.match(r'Metadata output file cannot be in the {} directory'.format(match))
+    excinfo.match(r"Metadata output file cannot be in the {} directory".format(match))
 
 
-@pytest.mark.parametrize('source_is_symlink, dest_is_symlink, use_files', build_same_file_and_dir_test_cases())
+@pytest.mark.parametrize("source_is_symlink, dest_is_symlink, use_files", build_same_file_and_dir_test_cases())
 def test_process_cli_request_source_is_destination(tmpdir, source_is_symlink, dest_is_symlink, use_files):
     source, dest = build_same_files_and_dirs(tmpdir, source_is_symlink, dest_is_symlink, use_files)
 
     with pytest.raises(BadUserArgumentError) as excinfo:
         aws_encryption_sdk_cli.process_cli_request(
-            stream_args={'mode': 'encrypt'},
-            parsed_args=MagicMock(
-                input=source,
-                output=dest,
-                recursive=True,
-                interactive=False,
-                no_overwrite=False
-            )
+            stream_args={"mode": "encrypt"},
+            parsed_args=MagicMock(input=source, output=dest, recursive=True, interactive=False, no_overwrite=False),
         )
-    excinfo.match(r'Destination and source cannot be the same')
+    excinfo.match(r"Destination and source cannot be the same")
 
 
 def test_process_cli_request_source_dir_nonrecursive(tmpdir, patch_iohandler):
-    source = tmpdir.mkdir('source')
-    destination = tmpdir.mkdir('destination')
+    source = tmpdir.mkdir("source")
+    destination = tmpdir.mkdir("destination")
     metadata_writer = MetadataWriter(True)()
     aws_encryption_sdk_cli.process_cli_request(
         stream_args=sentinel.stream_args,
@@ -270,8 +248,8 @@ def test_process_cli_request_source_dir_nonrecursive(tmpdir, patch_iohandler):
             decode=sentinel.decode_input,
             encode=sentinel.encode_output,
             encryption_context=sentinel.encryption_context,
-            required_encryption_context_keys=sentinel.required_keys
-        )
+            required_encryption_context_keys=sentinel.required_keys,
+        ),
     )
 
     patch_iohandler.assert_called_once_with(
@@ -281,7 +259,7 @@ def test_process_cli_request_source_dir_nonrecursive(tmpdir, patch_iohandler):
         decode_input=sentinel.decode_input,
         encode_output=sentinel.encode_output,
         required_encryption_context=sentinel.encryption_context,
-        required_encryption_context_keys=sentinel.required_keys
+        required_encryption_context_keys=sentinel.required_keys,
     )
     assert not patch_iohandler.return_value.process_single_operation.called
     assert not patch_iohandler.return_value.process_dir.called
@@ -289,13 +267,13 @@ def test_process_cli_request_source_dir_nonrecursive(tmpdir, patch_iohandler):
 
 
 def test_process_cli_request_source_dir_destination_nondir(tmpdir):
-    source = tmpdir.mkdir('source')
+    source = tmpdir.mkdir("source")
     with pytest.raises(BadUserArgumentError) as excinfo:
         aws_encryption_sdk_cli.process_cli_request(
-            stream_args={'mode': 'encrypt'},
+            stream_args={"mode": "encrypt"},
             parsed_args=MagicMock(
                 input=str(source),
-                output=str(tmpdir.join('destination')),
+                output=str(tmpdir.join("destination")),
                 recursive=True,
                 interactive=False,
                 no_overwrite=False,
@@ -303,15 +281,15 @@ def test_process_cli_request_source_dir_destination_nondir(tmpdir):
                 encode=False,
                 metadata_output=MetadataWriter(True)(),
                 encryption_context={},
-                required_encryption_context_keys=[]
-            )
+                required_encryption_context_keys=[],
+            ),
         )
-    excinfo.match(r'If operating on a source directory, destination must be an existing directory')
+    excinfo.match(r"If operating on a source directory, destination must be an existing directory")
 
 
 def test_process_cli_request_source_dir_destination_dir(tmpdir, patch_iohandler):
-    source = tmpdir.mkdir('source_dir')
-    destination = tmpdir.mkdir('destination_dir')
+    source = tmpdir.mkdir("source_dir")
+    destination = tmpdir.mkdir("destination_dir")
     aws_encryption_sdk_cli.process_cli_request(
         stream_args=sentinel.stream_args,
         parsed_args=MagicMock(
@@ -323,15 +301,12 @@ def test_process_cli_request_source_dir_destination_dir(tmpdir, patch_iohandler)
             suffix=sentinel.suffix,
             decode=sentinel.decode_input,
             encode=sentinel.encode_output,
-            metadata_output=MetadataWriter(True)()
-        )
+            metadata_output=MetadataWriter(True)(),
+        ),
     )
 
     patch_iohandler.return_value.process_dir.assert_called_once_with(
-        stream_args=sentinel.stream_args,
-        source=str(source),
-        destination=str(destination),
-        suffix=sentinel.suffix
+        stream_args=sentinel.stream_args, source=str(source), destination=str(destination), suffix=sentinel.suffix
     )
     assert not patch_iohandler.return_value.process_single_file.called
     assert not patch_iohandler.return_value.process_single_operation.called
@@ -340,77 +315,68 @@ def test_process_cli_request_source_dir_destination_dir(tmpdir, patch_iohandler)
 def test_process_cli_request_source_stdin_destination_dir(tmpdir):
     with pytest.raises(BadUserArgumentError) as excinfo:
         aws_encryption_sdk_cli.process_cli_request(
-            stream_args={'mode': 'encrypt'},
+            stream_args={"mode": "encrypt"},
             parsed_args=MagicMock(
-                input='-',
-                output=str(tmpdir),
-                recursive=False,
-                interactive=False,
-                no_overwrite=False
-            )
+                input="-", output=str(tmpdir), recursive=False, interactive=False, no_overwrite=False
+            ),
         )
-    excinfo.match(r'Destination may not be a directory when source is stdin')
+    excinfo.match(r"Destination may not be a directory when source is stdin")
 
 
 def test_process_cli_request_source_stdin(tmpdir, patch_iohandler):
-    destination = tmpdir.join('destination')
+    destination = tmpdir.join("destination")
     mock_parsed_args = MagicMock(
-        input='-',
+        input="-",
         output=str(destination),
         recursive=False,
         interactive=sentinel.interactive,
         no_overwrite=sentinel.no_overwrite,
         decode=sentinel.decode_input,
         encode=sentinel.encode_output,
-        metadata_output=MetadataWriter(True)()
+        metadata_output=MetadataWriter(True)(),
     )
-    aws_encryption_sdk_cli.process_cli_request(
-        stream_args=sentinel.stream_args,
-        parsed_args=mock_parsed_args
-    )
+    aws_encryption_sdk_cli.process_cli_request(stream_args=sentinel.stream_args, parsed_args=mock_parsed_args)
     assert not patch_iohandler.return_value.process_dir.called
     assert not patch_iohandler.return_value.process_single_file.called
     patch_iohandler.return_value.process_single_operation.assert_called_once_with(
-        stream_args=sentinel.stream_args,
-        source='-',
-        destination=str(destination)
+        stream_args=sentinel.stream_args, source="-", destination=str(destination)
     )
 
 
 def test_process_cli_request_source_file_destination_dir(tmpdir, patch_iohandler):
-    source = tmpdir.join('source')
-    source.write('some data')
-    destination = tmpdir.mkdir('destination')
+    source = tmpdir.join("source")
+    source.write("some data")
+    destination = tmpdir.mkdir("destination")
     aws_encryption_sdk_cli.process_cli_request(
-        stream_args={'mode': sentinel.mode},
+        stream_args={"mode": sentinel.mode},
         parsed_args=MagicMock(
             input=str(source),
             output=str(destination),
             recursive=False,
             interactive=sentinel.interactive,
             no_overwrite=sentinel.no_overwrite,
-            suffix='CUSTOM_SUFFIX',
+            suffix="CUSTOM_SUFFIX",
             decode=sentinel.decode_input,
             encode=sentinel.encode_output,
-            metadata_output=MetadataWriter(True)()
-        )
+            metadata_output=MetadataWriter(True)(),
+        ),
     )
     assert not patch_iohandler.return_value.process_dir.called
     assert not patch_iohandler.return_value.process_single_operation.called
     patch_iohandler.return_value.process_single_file.assert_called_once_with(
-        stream_args={'mode': sentinel.mode},
+        stream_args={"mode": sentinel.mode},
         source=str(source),
-        destination=str(destination.join('sourceCUSTOM_SUFFIX'))
+        destination=str(destination.join("sourceCUSTOM_SUFFIX")),
     )
 
 
 def test_process_cli_request_source_file_destination_file(tmpdir, patch_iohandler):
-    source = tmpdir.join('source')
-    source.write('some data')
-    destination = tmpdir.join('destination')
+    source = tmpdir.join("source")
+    source.write("some data")
+    destination = tmpdir.join("destination")
 
     aws_encryption_sdk_cli.process_cli_request(
-        stream_args={'mode': sentinel.mode},
+        stream_args={"mode": sentinel.mode},
         parsed_args=MagicMock(
             input=str(source),
             output=str(destination),
@@ -419,26 +385,24 @@ def test_process_cli_request_source_file_destination_file(tmpdir, patch_iohandle
             no_overwrite=sentinel.no_overwrite,
             decode=sentinel.decode_input,
             encode=sentinel.encode_output,
-            metadata_output=MetadataWriter(True)()
-        )
+            metadata_output=MetadataWriter(True)(),
+        ),
     )
     assert not patch_iohandler.return_value.process_dir.called
     assert not patch_iohandler.return_value.process_single_operation.called
     patch_iohandler.return_value.process_single_file.assert_called_once_with(
-        stream_args={'mode': sentinel.mode},
-        source=str(source),
-        destination=str(destination)
+        stream_args={"mode": sentinel.mode}, source=str(source), destination=str(destination)
     )
 
 
 def test_process_cli_request_invalid_source(tmpdir):
-    target = os.path.join(str(tmpdir), 'test_targets.*')
+    target = os.path.join(str(tmpdir), "test_targets.*")
     with pytest.raises(BadUserArgumentError) as excinfo:
         aws_encryption_sdk_cli.process_cli_request(
             stream_args={},
             parsed_args=MagicMock(
                 input=target,
-                output='a specific destination',
+                output="a specific destination",
                 recursive=False,
                 interactive=False,
                 no_overwrite=False,
@@ -446,51 +410,47 @@ def test_process_cli_request_invalid_source(tmpdir):
                 encode=False,
                 metadata_output=MetadataWriter(True)(),
                 encryption_context={},
-                required_encryption_context_keys=[]
-            )
+                required_encryption_context_keys=[],
+            ),
         )
-    excinfo.match(r'Invalid source.  Must be a valid pathname pattern or stdin \(-\)')
+    excinfo.match(r"Invalid source.  Must be a valid pathname pattern or stdin \(-\)")
 
 
 def test_process_cli_request_globbed_source_non_directory_target(tmpdir, patch_iohandler):
-    plaintext_dir = tmpdir.mkdir('plaintext')
-    test_file = plaintext_dir.join('testing.aa')
-    test_file.write(b'some data here!')
-    test_file = plaintext_dir.join('testing.bb')
-    test_file.write(b'some data here!')
-    ciphertext_dir = tmpdir.mkdir('ciphertext')
-    target_file = ciphertext_dir.join('target_file')
-    source = os.path.join(str(plaintext_dir), 'testing.*')
+    plaintext_dir = tmpdir.mkdir("plaintext")
+    test_file = plaintext_dir.join("testing.aa")
+    test_file.write(b"some data here!")
+    test_file = plaintext_dir.join("testing.bb")
+    test_file.write(b"some data here!")
+    ciphertext_dir = tmpdir.mkdir("ciphertext")
+    target_file = ciphertext_dir.join("target_file")
+    source = os.path.join(str(plaintext_dir), "testing.*")
 
     with pytest.raises(BadUserArgumentError) as excinfo:
         aws_encryption_sdk_cli.process_cli_request(
-            stream_args={'mode': 'encrypt'},
+            stream_args={"mode": "encrypt"},
             parsed_args=MagicMock(
-                input=source,
-                output=str(target_file),
-                recursive=False,
-                interactive=False,
-                no_overwrite=False
-            )
+                input=source, output=str(target_file), recursive=False, interactive=False, no_overwrite=False
+            ),
         )
 
-    excinfo.match('If operating on multiple sources, destination must be an existing directory')
+    excinfo.match("If operating on multiple sources, destination must be an existing directory")
     assert not patch_iohandler.return_value.process_dir.called
     assert not patch_iohandler.return_value.process_single_file.called
 
 
 def test_process_cli_request_source_contains_directory_nonrecursive(tmpdir, patch_iohandler):
-    plaintext_dir = tmpdir.mkdir('plaintext')
-    test_file_a = plaintext_dir.join('testing.aa')
-    test_file_a.write(b'some data here!')
-    test_file_c = plaintext_dir.join('testing.cc')
-    test_file_c.write(b'some data here!')
-    plaintext_dir.mkdir('testing.bb')
-    ciphertext_dir = tmpdir.mkdir('ciphertext')
-    source = os.path.join(str(plaintext_dir), 'testing.*')
+    plaintext_dir = tmpdir.mkdir("plaintext")
+    test_file_a = plaintext_dir.join("testing.aa")
+    test_file_a.write(b"some data here!")
+    test_file_c = plaintext_dir.join("testing.cc")
+    test_file_c.write(b"some data here!")
+    plaintext_dir.mkdir("testing.bb")
+    ciphertext_dir = tmpdir.mkdir("ciphertext")
+    source = os.path.join(str(plaintext_dir), "testing.*")
 
     aws_encryption_sdk_cli.process_cli_request(
-        stream_args={'mode': 'encrypt'},
+        stream_args={"mode": "encrypt"},
         parsed_args=MagicMock(
             input=source,
             output=str(ciphertext_dir),
@@ -499,148 +459,130 @@ def test_process_cli_request_source_contains_directory_nonrecursive(tmpdir, patc
             no_overwrite=False,
             encode=False,
             decode=False,
-            metadata_output=MetadataWriter(True)()
-        )
+            metadata_output=MetadataWriter(True)(),
+        ),
     )
 
     assert not patch_iohandler.return_value.process_dir.called
     patch_iohandler.return_value.process_single_file.assert_has_calls(
         calls=[
-            call(
-                stream_args={'mode': 'encrypt'},
-                source=str(source_file),
-                destination=ANY
-            )
+            call(stream_args={"mode": "encrypt"}, source=str(source_file), destination=ANY)
             for source_file in (test_file_a, test_file_c)
         ],
-        any_order=True
+        any_order=True,
     )
 
 
-@pytest.mark.parametrize('args, stream_args', (
+@pytest.mark.parametrize(
+    "args, stream_args",
     (
-        MagicMock(
-            action=sentinel.mode,
-            encryption_context=None,
-            algorithm=None,
-            frame_length=None,
-            max_length=None
+        (
+            MagicMock(
+                action=sentinel.mode, encryption_context=None, algorithm=None, frame_length=None, max_length=None
+            ),
+            {"materials_manager": sentinel.materials_manager, "mode": sentinel.mode},
         ),
-        {
-            'materials_manager': sentinel.materials_manager,
-            'mode': sentinel.mode
-        }
+        (
+            MagicMock(
+                action=sentinel.mode,
+                encryption_context=None,
+                algorithm=None,
+                frame_length=None,
+                max_length=sentinel.max_length,
+            ),
+            {
+                "materials_manager": sentinel.materials_manager,
+                "mode": sentinel.mode,
+                "max_body_length": sentinel.max_length,
+            },
+        ),
+        (
+            MagicMock(
+                action=sentinel.mode, encryption_context=None, algorithm=None, frame_length=None, max_length=None
+            ),
+            {"materials_manager": sentinel.materials_manager, "mode": sentinel.mode},
+        ),
+        (
+            MagicMock(
+                action=sentinel.mode,
+                encryption_context=sentinel.encryption_context,
+                algorithm="AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384",
+                frame_length=sentinel.frame_length,
+                max_length=None,
+            ),
+            {"materials_manager": sentinel.materials_manager, "mode": sentinel.mode},
+        ),
+        (
+            MagicMock(
+                action="encrypt",
+                encryption_context={"encryption": "context", "with": "keys"},
+                algorithm="AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384",
+                frame_length=sentinel.frame_length,
+                max_length=None,
+            ),
+            {
+                "materials_manager": sentinel.materials_manager,
+                "mode": "encrypt",
+                "encryption_context": {"encryption": "context", "with": "keys"},
+                "algorithm": aws_encryption_sdk.Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+                "frame_length": sentinel.frame_length,
+            },
+        ),
+        (
+            MagicMock(
+                action="encrypt",
+                encryption_context={},
+                algorithm="AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384",
+                frame_length=sentinel.frame_length,
+                max_length=None,
+            ),
+            {
+                "materials_manager": sentinel.materials_manager,
+                "mode": "encrypt",
+                "algorithm": aws_encryption_sdk.Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+                "frame_length": sentinel.frame_length,
+                "encryption_context": {},
+            },
+        ),
+        (
+            MagicMock(
+                action="encrypt",
+                encryption_context={"encryption": "context", "with": "keys"},
+                algorithm=None,
+                frame_length=sentinel.frame_length,
+                max_length=None,
+            ),
+            {
+                "materials_manager": sentinel.materials_manager,
+                "mode": "encrypt",
+                "encryption_context": {"encryption": "context", "with": "keys"},
+                "frame_length": sentinel.frame_length,
+            },
+        ),
+        (
+            MagicMock(
+                action="encrypt",
+                encryption_context={"encryption": "context", "with": "keys"},
+                algorithm="AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384",
+                frame_length=None,
+                max_length=None,
+            ),
+            {
+                "materials_manager": sentinel.materials_manager,
+                "mode": "encrypt",
+                "encryption_context": {"encryption": "context", "with": "keys"},
+                "algorithm": aws_encryption_sdk.Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+            },
+        ),
     ),
-    (
-        MagicMock(
-            action=sentinel.mode,
-            encryption_context=None,
-            algorithm=None,
-            frame_length=None,
-            max_length=sentinel.max_length
-        ),
-        {
-            'materials_manager': sentinel.materials_manager,
-            'mode': sentinel.mode,
-            'max_body_length': sentinel.max_length
-        }
-    ),
-    (
-        MagicMock(
-            action=sentinel.mode,
-            encryption_context=None,
-            algorithm=None,
-            frame_length=None,
-            max_length=None
-        ),
-        {
-            'materials_manager': sentinel.materials_manager,
-            'mode': sentinel.mode,
-        }
-    ),
-    (
-        MagicMock(
-            action=sentinel.mode,
-            encryption_context=sentinel.encryption_context,
-            algorithm='AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384',
-            frame_length=sentinel.frame_length,
-            max_length=None
-        ),
-        {
-            'materials_manager': sentinel.materials_manager,
-            'mode': sentinel.mode,
-        }
-    ),
-    (
-        MagicMock(
-            action='encrypt',
-            encryption_context={'encryption': 'context', 'with': 'keys'},
-            algorithm='AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384',
-            frame_length=sentinel.frame_length,
-            max_length=None
-        ),
-        {
-            'materials_manager': sentinel.materials_manager,
-            'mode': 'encrypt',
-            'encryption_context': {'encryption': 'context', 'with': 'keys'},
-            'algorithm': aws_encryption_sdk.Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-            'frame_length': sentinel.frame_length,
-        }
-    ),
-    (
-        MagicMock(
-            action='encrypt',
-            encryption_context={},
-            algorithm='AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384',
-            frame_length=sentinel.frame_length,
-            max_length=None
-        ),
-        {
-            'materials_manager': sentinel.materials_manager,
-            'mode': 'encrypt',
-            'algorithm': aws_encryption_sdk.Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-            'frame_length': sentinel.frame_length,
-            'encryption_context': {}
-        }
-    ),
-    (
-        MagicMock(
-            action='encrypt',
-            encryption_context={'encryption': 'context', 'with': 'keys'},
-            algorithm=None,
-            frame_length=sentinel.frame_length,
-            max_length=None
-        ),
-        {
-            'materials_manager': sentinel.materials_manager,
-            'mode': 'encrypt',
-            'encryption_context': {'encryption': 'context', 'with': 'keys'},
-            'frame_length': sentinel.frame_length
-        }
-    ),
-    (
-        MagicMock(
-            action='encrypt',
-            encryption_context={'encryption': 'context', 'with': 'keys'},
-            algorithm='AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384',
-            frame_length=None,
-            max_length=None
-        ),
-        {
-            'materials_manager': sentinel.materials_manager,
-            'mode': 'encrypt',
-            'encryption_context': {'encryption': 'context', 'with': 'keys'},
-            'algorithm': aws_encryption_sdk.Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384
-        }
-    )
-))
+)
 def test_stream_kwargs_from_args(args, stream_args):
     assert aws_encryption_sdk_cli.stream_kwargs_from_args(args, sentinel.materials_manager) == stream_args
 
 
 @pytest.fixture
 def patch_for_cli(mocker):
-    mocker.patch.object(aws_encryption_sdk_cli, 'parse_args')
+    mocker.patch.object(aws_encryption_sdk_cli, "parse_args")
     aws_encryption_sdk_cli.parse_args.return_value = MagicMock(
         version=False,
         verbosity=sentinel.verbosity,
@@ -654,35 +596,29 @@ def patch_for_cli(mocker):
         no_overwrite=sentinel.no_overwrite,
         suffix=sentinel.suffix,
         decode=sentinel.decode_input,
-        encode=sentinel.encode_output
+        encode=sentinel.encode_output,
     )
-    mocker.patch.object(aws_encryption_sdk_cli, 'setup_logger')
-    mocker.patch.object(aws_encryption_sdk_cli, 'build_crypto_materials_manager_from_args')
+    mocker.patch.object(aws_encryption_sdk_cli, "setup_logger")
+    mocker.patch.object(aws_encryption_sdk_cli, "build_crypto_materials_manager_from_args")
     aws_encryption_sdk_cli.build_crypto_materials_manager_from_args.return_value = sentinel.crypto_materials_manager
-    mocker.patch.object(aws_encryption_sdk_cli, 'stream_kwargs_from_args')
+    mocker.patch.object(aws_encryption_sdk_cli, "stream_kwargs_from_args")
     aws_encryption_sdk_cli.stream_kwargs_from_args.return_value = sentinel.stream_args
-    mocker.patch.object(aws_encryption_sdk_cli, 'process_cli_request')
+    mocker.patch.object(aws_encryption_sdk_cli, "process_cli_request")
 
 
 def test_cli(patch_for_cli):
     test = aws_encryption_sdk_cli.cli(sentinel.raw_args)
 
     aws_encryption_sdk_cli.parse_args.assert_called_once_with(sentinel.raw_args)
-    aws_encryption_sdk_cli.setup_logger.assert_called_once_with(
-        sentinel.verbosity,
-        sentinel.quiet
-    )
+    aws_encryption_sdk_cli.setup_logger.assert_called_once_with(sentinel.verbosity, sentinel.quiet)
     aws_encryption_sdk_cli.build_crypto_materials_manager_from_args.assert_called_once_with(
-        key_providers_config=sentinel.master_keys,
-        caching_config=sentinel.caching_config
+        key_providers_config=sentinel.master_keys, caching_config=sentinel.caching_config
     )
     aws_encryption_sdk_cli.stream_kwargs_from_args.assert_called_once_with(
-        aws_encryption_sdk_cli.parse_args.return_value,
-        sentinel.crypto_materials_manager
+        aws_encryption_sdk_cli.parse_args.return_value, sentinel.crypto_materials_manager
     )
     aws_encryption_sdk_cli.process_cli_request.assert_called_once_with(
-        sentinel.stream_args,
-        aws_encryption_sdk_cli.parse_args.return_value
+        sentinel.stream_args, aws_encryption_sdk_cli.parse_args.return_value
     )
     assert test is None
 
@@ -698,7 +634,7 @@ def test_cli_unknown_error(patch_for_cli):
     aws_encryption_sdk_cli.process_cli_request.side_effect = Exception()
     test = aws_encryption_sdk_cli.cli()
 
-    assert test.startswith('Encountered unexpected ')
+    assert test.startswith("Encountered unexpected ")
 
 
 def kms_redacting_logger_stream(log_level):
@@ -712,28 +648,26 @@ def kms_redacting_logger_stream(log_level):
     return output_stream
 
 
-@pytest.mark.parametrize('log_level, requested_log_level', (
-    (logging.WARNING, ''),
-    (logging.INFO, '-v'),
-    (logging.DEBUG, '-vv')
-))
+@pytest.mark.parametrize(
+    "log_level, requested_log_level", ((logging.WARNING, ""), (logging.INFO, "-v"), (logging.DEBUG, "-vv"))
+)
 def test_cli_unknown_error_capture_stacktrace(patch_process_cli_request, tmpdir, log_level, requested_log_level):
     log_stream = kms_redacting_logger_stream(log_level)
-    plaintext = tmpdir.join('plaintext')
-    plaintext.write('some data')
-    message = 'THIS IS A REASONABLY UNIQUE ERROR MESSAGE #&*Y(HJFIWE'
+    plaintext = tmpdir.join("plaintext")
+    plaintext.write("some data")
+    message = "THIS IS A REASONABLY UNIQUE ERROR MESSAGE #&*Y(HJFIWE"
     patch_process_cli_request.side_effect = Exception(message)
 
-    test = aws_encryption_sdk_cli.cli(shlex.split(
-        '-Sd -i ' + str(plaintext) + ' -o ' + str(tmpdir.join('ciphertext')) + ' ' + requested_log_level
-    ))
+    test = aws_encryption_sdk_cli.cli(
+        shlex.split("-Sd -i " + str(plaintext) + " -o " + str(tmpdir.join("ciphertext")) + " " + requested_log_level)
+    )
 
     all_logs = log_stream.getvalue()
-    assert test.startswith('Encountered unexpected error: increase verbosity to see details.')
+    assert test.startswith("Encountered unexpected error: increase verbosity to see details.")
     assert message in test
     if log_level <= logging.DEBUG:
-        assert 'Traceback' in all_logs
+        assert "Traceback" in all_logs
         assert message in all_logs
     else:
-        assert 'Traceback' not in all_logs
+        assert "Traceback" not in all_logs
         assert message not in all_logs

--- a/test/unit/test_encoding.py
+++ b/test/unit/test_encoding.py
@@ -28,16 +28,16 @@ def test_base64io_bad_wrap():
     with pytest.raises(TypeError) as excinfo:
         Base64IO(7)
 
-    excinfo.match(r'Base64IO wrapped object must have attributes: *')
+    excinfo.match(r"Base64IO wrapped object must have attributes: *")
 
 
 def test_base64io_write_after_closed():
     with Base64IO(io.BytesIO()) as test:
         with pytest.raises(ValueError) as excinfo:
             test.close()
-            test.write(b'aksdhjf')
+            test.write(b"aksdhjf")
 
-    excinfo.match(r'I/O operation on closed file.')
+    excinfo.match(r"I/O operation on closed file.")
 
 
 def test_base64io_read_after_closed():
@@ -46,17 +46,17 @@ def test_base64io_read_after_closed():
             test.close()
             test.read()
 
-    excinfo.match(r'I/O operation on closed file.')
+    excinfo.match(r"I/O operation on closed file.")
 
 
-@pytest.mark.parametrize('method_name', ('isatty', 'seekable'))
+@pytest.mark.parametrize("method_name", ("isatty", "seekable"))
 def test_base64io_always_false_methods(method_name):
     test = Base64IO(io.BytesIO())
 
     assert not getattr(test, method_name)()
 
 
-@pytest.mark.parametrize('method_name', ('fileno', 'seek', 'tell', 'truncate'))
+@pytest.mark.parametrize("method_name", ("fileno", "seek", "tell", "truncate"))
 def test_unsupported_methods(method_name):
     test = Base64IO(io.BytesIO())
 
@@ -64,7 +64,7 @@ def test_unsupported_methods(method_name):
         getattr(test, method_name)()
 
 
-@pytest.mark.parametrize('method_name', ('flush', 'writable', 'readable'))
+@pytest.mark.parametrize("method_name", ("flush", "writable", "readable"))
 def test_passthrough_methods_present(monkeypatch, method_name):
     wrapped = io.BytesIO()
     monkeypatch.setattr(wrapped, method_name, lambda: sentinel.passthrough)
@@ -73,7 +73,7 @@ def test_passthrough_methods_present(monkeypatch, method_name):
     assert getattr(wrapper, method_name)() is sentinel.passthrough
 
 
-@pytest.mark.parametrize('method_name', ('writable', 'readable'))
+@pytest.mark.parametrize("method_name", ("writable", "readable"))
 def test_passthrough_methods_not_present(monkeypatch, method_name):
     wrapped = MagicMock()
     monkeypatch.delattr(wrapped, method_name, False)
@@ -82,15 +82,13 @@ def test_passthrough_methods_not_present(monkeypatch, method_name):
     assert not getattr(wrapper, method_name)()
 
 
-@pytest.mark.parametrize('mode, method_name, expected', (
-    ('wb', 'writable', True),
-    ('rb', 'readable', True),
-    ('rb', 'writable', False),
-    ('wb', 'readable', False)
-))
+@pytest.mark.parametrize(
+    "mode, method_name, expected",
+    (("wb", "writable", True), ("rb", "readable", True), ("rb", "writable", False), ("wb", "readable", False)),
+)
 def test_passthrough_methods_file(tmpdir, method_name, mode, expected):
-    source = tmpdir.join('source')
-    source.write('some data')
+    source = tmpdir.join("source")
+    source.write("some data")
 
     with open(str(source), mode) as reader:
         with Base64IO(reader) as b64:
@@ -102,10 +100,7 @@ def test_passthrough_methods_file(tmpdir, method_name, mode, expected):
         assert not test
 
 
-@pytest.mark.parametrize('patch_method, call_method, call_arg', (
-    ('writable', 'write', b''),
-    ('readable', 'read', 0)
-))
+@pytest.mark.parametrize("patch_method, call_method, call_arg", (("writable", "write", b""), ("readable", "read", 0)))
 def test_non_interactive_error(monkeypatch, patch_method, call_method, call_arg):
     wrapped = io.BytesIO()
     monkeypatch.setattr(wrapped, patch_method, lambda: False)
@@ -114,7 +109,7 @@ def test_non_interactive_error(monkeypatch, patch_method, call_method, call_arg)
         with pytest.raises(IOError) as excinfo:
             getattr(wrapper, call_method)(call_arg)
 
-    excinfo.match(r'Stream is not ' + patch_method)
+    excinfo.match(r"Stream is not " + patch_method)
 
 
 def build_test_cases():
@@ -140,15 +135,14 @@ def build_test_cases():
 
 
 @pytest.mark.parametrize(
-    'bytes_to_generate, bytes_per_round, number_of_rounds, total_bytes_to_expect',
-    build_test_cases()
+    "bytes_to_generate, bytes_per_round, number_of_rounds, total_bytes_to_expect", build_test_cases()
 )
 def test_base64io_decode(bytes_to_generate, bytes_per_round, number_of_rounds, total_bytes_to_expect):
     plaintext_source = os.urandom(bytes_to_generate)
     plaintext_b64 = io.BytesIO(base64.b64encode(plaintext_source))
     plaintext_wrapped = Base64IO(plaintext_b64)
 
-    test = b''
+    test = b""
     for _round in range(number_of_rounds):
         test += plaintext_wrapped.read(bytes_per_round)
 
@@ -156,7 +150,7 @@ def test_base64io_decode(bytes_to_generate, bytes_per_round, number_of_rounds, t
     assert test == plaintext_source[:total_bytes_to_expect]
 
 
-@pytest.mark.parametrize('source_bytes', [case[0] for case in build_test_cases()])
+@pytest.mark.parametrize("source_bytes", [case[0] for case in build_test_cases()])
 def test_base64io_encode_context_manager(source_bytes):
     plaintext_source = os.urandom(source_bytes)
     plaintext_b64 = base64.b64encode(plaintext_source)
@@ -181,7 +175,7 @@ def test_base64io_encode_context_manager_reuse():
         with stream as plaintext_wrapped:
             plaintext_wrapped.read()
 
-    excinfo.match(r'I/O operation on closed file.')
+    excinfo.match(r"I/O operation on closed file.")
 
 
 def test_base64io_encode_use_after_context_manager_exit():
@@ -198,10 +192,10 @@ def test_base64io_encode_use_after_context_manager_exit():
     with pytest.raises(ValueError) as excinfo:
         stream.read()
 
-    excinfo.match(r'I/O operation on closed file.')
+    excinfo.match(r"I/O operation on closed file.")
 
 
-@pytest.mark.parametrize('source_bytes', [case[0] for case in build_test_cases()])
+@pytest.mark.parametrize("source_bytes", [case[0] for case in build_test_cases()])
 def test_base64io_encode(source_bytes):
     plaintext_source = os.urandom(source_bytes)
     plaintext_b64 = base64.b64encode(plaintext_source)
@@ -216,12 +210,9 @@ def test_base64io_encode(source_bytes):
     assert plaintext_stream.getvalue() == plaintext_b64
 
 
-@pytest.mark.parametrize('bytes_to_read, expected_bytes_read', (
-    (-1, io.DEFAULT_BUFFER_SIZE),
-    (0, io.DEFAULT_BUFFER_SIZE),
-    (1, 1),
-    (10, 10)
-))
+@pytest.mark.parametrize(
+    "bytes_to_read, expected_bytes_read", ((-1, io.DEFAULT_BUFFER_SIZE), (0, io.DEFAULT_BUFFER_SIZE), (1, 1), (10, 10))
+)
 def test_base64io_decode_readline(bytes_to_read, expected_bytes_read):
     source_plaintext = os.urandom(io.DEFAULT_BUFFER_SIZE * 2)
     source_stream = io.BytesIO(base64.b64encode(source_plaintext))
@@ -235,10 +226,9 @@ def test_base64io_decode_readline(bytes_to_read, expected_bytes_read):
 def build_b64_with_whitespace(source_bytes, line_length):
     plaintext_source = os.urandom(source_bytes)
     b64_plaintext = io.BytesIO(base64.b64encode(plaintext_source))
-    b64_plaintext_with_whitespace = b'\n'.join([
-        line for line
-        in iter(functools.partial(b64_plaintext.read, line_length), b'')
-    ])
+    b64_plaintext_with_whitespace = b"\n".join(
+        [line for line in iter(functools.partial(b64_plaintext.read, line_length), b"")]
+    )
     return plaintext_source, b64_plaintext_with_whitespace
 
 
@@ -249,18 +239,18 @@ def build_whitespace_testcases():
 
     # first read is mostly whitespace
     plaintext, b64_plaintext = build_b64_with_whitespace(100, 20)
-    b64_plaintext = (b' ' * 80) + b64_plaintext
+    b64_plaintext = (b" " * 80) + b64_plaintext
     scenarios.append((plaintext, b64_plaintext, 100))
 
     # first several reads are entirely whitespace
     plaintext, b64_plaintext = build_b64_with_whitespace(100, 20)
-    b64_plaintext = (b' ' * 500) + b64_plaintext
+    b64_plaintext = (b" " * 500) + b64_plaintext
     scenarios.append((plaintext, b64_plaintext, 100))
 
     return scenarios
 
 
-@pytest.mark.parametrize('plaintext_source, b64_plaintext_with_whitespace, read_bytes', build_whitespace_testcases())
+@pytest.mark.parametrize("plaintext_source, b64_plaintext_with_whitespace, read_bytes", build_whitespace_testcases())
 def test_base64io_decode_with_whitespace(plaintext_source, b64_plaintext_with_whitespace, read_bytes):
     with Base64IO(io.BytesIO(b64_plaintext_with_whitespace)) as decoder:
         test = decoder.read(read_bytes)
@@ -268,9 +258,9 @@ def test_base64io_decode_with_whitespace(plaintext_source, b64_plaintext_with_wh
     assert test == plaintext_source[:read_bytes]
 
 
-@pytest.mark.parametrize('plaintext_source, b64_plaintext_with_whitespace, read_bytes', (
-    (b'\x00\x00\x00', b'AAAA', 3),
-))
+@pytest.mark.parametrize(
+    "plaintext_source, b64_plaintext_with_whitespace, read_bytes", ((b"\x00\x00\x00", b"AAAA", 3),)
+)
 def test_base64io_decode_parametrized_null_bytes(plaintext_source, b64_plaintext_with_whitespace, read_bytes):
     # Verifies that pytest is handling null bytes correctly (broken in 3.3.0)
     # https://github.com/pytest-dev/pytest/issues/2957
@@ -281,7 +271,7 @@ def test_base64io_decode_parametrized_null_bytes(plaintext_source, b64_plaintext
 
 
 def test_base64io_decode_read_only_from_buffer():
-    plaintext_source = b'12345'
+    plaintext_source = b"12345"
     plaintext_b64 = io.BytesIO(base64.b64encode(plaintext_source))
     plaintext_wrapped = Base64IO(plaintext_b64)
 
@@ -289,9 +279,9 @@ def test_base64io_decode_read_only_from_buffer():
     test_2 = plaintext_wrapped.read(1)
     test_3 = plaintext_wrapped.read()
 
-    assert test_1 == b'1'
-    assert test_2 == b'2'
-    assert test_3 == b'345'
+    assert test_1 == b"1"
+    assert test_2 == b"2"
+    assert test_3 == b"345"
 
 
 def test_base64io_decode_context_manager():
@@ -320,12 +310,10 @@ def test_base64io_decode_context_manager_close_source():
     assert source_stream.closed
 
 
-@pytest.mark.parametrize('hint_bytes, expected_bytes_read', (
-    (-1, 102400),
-    (0, 102400),
-    (1, io.DEFAULT_BUFFER_SIZE),
-    (io.DEFAULT_BUFFER_SIZE + 99, io.DEFAULT_BUFFER_SIZE * 2)
-))
+@pytest.mark.parametrize(
+    "hint_bytes, expected_bytes_read",
+    ((-1, 102400), (0, 102400), (1, io.DEFAULT_BUFFER_SIZE), (io.DEFAULT_BUFFER_SIZE + 99, io.DEFAULT_BUFFER_SIZE * 2)),
+)
 def test_base64io_decode_readlines(hint_bytes, expected_bytes_read):
     source_plaintext = os.urandom(102400)
     source_stream = io.BytesIO(base64.b64encode(source_plaintext))
@@ -341,7 +329,7 @@ def test_base64io_decode_readlines(hint_bytes, expected_bytes_read):
 
 def test_base64io_encode_writelines():
     source_plaintext = [os.urandom(1024) for _ in range(100)]
-    b64_plaintext = base64.b64encode(b''.join(source_plaintext))
+    b64_plaintext = base64.b64encode(b"".join(source_plaintext))
 
     test = io.BytesIO()
     with Base64IO(test) as encoder:
@@ -352,16 +340,16 @@ def test_base64io_encode_writelines():
 
 def test_base64io_decode_file(tmpdir):
     source_plaintext = os.urandom(1024 * 1024)
-    b64_plaintext = tmpdir.join('base64_plaintext')
+    b64_plaintext = tmpdir.join("base64_plaintext")
     b64_plaintext.write(base64.b64encode(source_plaintext))
-    decoded_plaintext = tmpdir.join('decoded_plaintext')
+    decoded_plaintext = tmpdir.join("decoded_plaintext")
 
-    with open(str(b64_plaintext), 'rb') as source, open(str(decoded_plaintext), 'wb') as raw:
+    with open(str(b64_plaintext), "rb") as source, open(str(decoded_plaintext), "wb") as raw:
         with Base64IO(source) as decoder:
             for chunk in decoder:
                 raw.write(chunk)
 
-    with open(str(decoded_plaintext), 'rb') as raw:
+    with open(str(decoded_plaintext), "rb") as raw:
         decoded = raw.read()
 
     assert decoded == source_plaintext
@@ -370,18 +358,18 @@ def test_base64io_decode_file(tmpdir):
 def test_base64io_encode_file(tmpdir):
     source_plaintext = os.urandom(1024 * 1024)
     plaintext_b64 = base64.b64encode(source_plaintext)
-    plaintext = tmpdir.join('plaintext')
-    b64_plaintext = tmpdir.join('base64_plaintext')
+    plaintext = tmpdir.join("plaintext")
+    b64_plaintext = tmpdir.join("base64_plaintext")
 
-    with open(str(plaintext), 'wb') as file:
+    with open(str(plaintext), "wb") as file:
         file.write(source_plaintext)
 
-    with open(str(plaintext), 'rb') as source, open(str(b64_plaintext), 'wb') as target:
+    with open(str(plaintext), "rb") as source, open(str(b64_plaintext), "wb") as target:
         with Base64IO(target) as encoder:
             for chunk in source:
                 encoder.write(chunk)
 
-    with open(str(b64_plaintext), 'rb') as file2:
+    with open(str(b64_plaintext), "rb") as file2:
         encoded = file2.read()
 
     assert encoded == plaintext_b64

--- a/test/unit/test_encoding.py
+++ b/test/unit/test_encoding.py
@@ -16,8 +16,8 @@ import functools
 import io
 import os
 
-from mock import MagicMock, sentinel
 import pytest
+from mock import MagicMock, sentinel
 
 from aws_encryption_sdk_cli.internal.encoding import Base64IO
 

--- a/test/unit/test_io_handling.py
+++ b/test/unit/test_io_handling.py
@@ -26,18 +26,18 @@ from aws_encryption_sdk_cli.internal import identifiers, io_handling, metadata
 from .unit_test_utils import WINDOWS_SKIP_MESSAGE, is_windows
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
-DATA = b'aosidhjf9aiwhj3f98wiaj49c8a3hj49f8uwa0edifja9w843hj98'
+DATA = b"aosidhjf9aiwhj3f98wiaj49c8a3hj49f8uwa0edifja9w843hj98"
 
 
 @pytest.yield_fixture
 def patch_makedirs(mocker):
-    mocker.patch.object(io_handling.os, 'makedirs')
+    mocker.patch.object(io_handling.os, "makedirs")
     yield io_handling.os.makedirs
 
 
 @pytest.yield_fixture
 def patch_aws_encryption_sdk_stream(mocker):
-    mocker.patch.object(io_handling.aws_encryption_sdk, 'stream')
+    mocker.patch.object(io_handling.aws_encryption_sdk, "stream")
     mock_stream = MagicMock()
     io_handling.aws_encryption_sdk.stream.return_value.__enter__.return_value = mock_stream
     mock_stream.__iter__ = MagicMock(return_value=iter((sentinel.chunk_1, sentinel.chunk_2)))
@@ -46,51 +46,51 @@ def patch_aws_encryption_sdk_stream(mocker):
 
 @pytest.fixture
 def patch_os_remove(mocker):
-    mocker.patch.object(io_handling.os, 'remove')
+    mocker.patch.object(io_handling.os, "remove")
     return io_handling.os.remove
 
 
 @pytest.fixture
 def patch_single_io_write(mocker):
-    mocker.patch.object(io_handling.IOHandler, '_single_io_write')
+    mocker.patch.object(io_handling.IOHandler, "_single_io_write")
     return io_handling.IOHandler._single_io_write
 
 
 @pytest.fixture
 def patch_for_process_single_operation(mocker, patch_single_io_write):
-    mocker.patch.object(io_handling, '_stdout')
-    mocker.patch.object(io_handling, '_stdin')
-    mocker.patch.object(io_handling, '_ensure_dir_exists')
+    mocker.patch.object(io_handling, "_stdout")
+    mocker.patch.object(io_handling, "_stdin")
+    mocker.patch.object(io_handling, "_ensure_dir_exists")
 
 
 @pytest.yield_fixture
 def patch_input(mocker):
-    mocker.patch.object(io_handling.six.moves, 'input')
+    mocker.patch.object(io_handling.six.moves, "input")
     yield io_handling.six.moves.input
 
 
 @pytest.yield_fixture
 def patch_process_single_operation(mocker):
-    mocker.patch.object(io_handling.IOHandler, 'process_single_operation')
+    mocker.patch.object(io_handling.IOHandler, "process_single_operation")
     yield io_handling.IOHandler.process_single_operation
 
 
 @pytest.yield_fixture
 def patch_should_write_file(mocker):
-    mocker.patch.object(io_handling.IOHandler, '_should_write_file')
+    mocker.patch.object(io_handling.IOHandler, "_should_write_file")
     io_handling.IOHandler._should_write_file.return_value = True
     yield io_handling.IOHandler._should_write_file
 
 
 @pytest.fixture
 def patch_json_ready_header(mocker):
-    mocker.patch.object(io_handling, 'json_ready_header')
+    mocker.patch.object(io_handling, "json_ready_header")
     return io_handling.json_ready_header
 
 
 @pytest.fixture
 def patch_json_ready_header_auth(mocker):
-    mocker.patch.object(io_handling, 'json_ready_header_auth')
+    mocker.patch.object(io_handling, "json_ready_header_auth")
     return io_handling.json_ready_header_auth
 
 
@@ -101,7 +101,7 @@ GOOD_IOHANDLER_KWARGS = dict(
     decode_input=False,
     encode_output=False,
     required_encryption_context={},
-    required_encryption_context_keys=[]
+    required_encryption_context_keys=[],
 )
 
 
@@ -132,36 +132,36 @@ def test_file_exists_error():
 
 
 def test_ensure_dir_exists_already_exists(tmpdir):
-    target_dir = tmpdir.mkdir('target')
+    target_dir = tmpdir.mkdir("target")
     io_handling._ensure_dir_exists(str(target_dir))
 
 
 def test_ensure_dir_exists_shallow_orphan(tmpdir):
-    target_parent = tmpdir.mkdir('parent')
-    target_dir = os.path.join(str(target_parent), 'target')
-    target_file = os.path.join(target_dir, 'file')
+    target_parent = tmpdir.mkdir("parent")
+    target_dir = os.path.join(str(target_parent), "target")
+    target_file = os.path.join(target_dir, "file")
     assert not os.path.exists(target_dir)
     io_handling._ensure_dir_exists(target_file)
     assert os.path.isdir(target_dir)
 
 
 def test_ensure_dir_exists_deep_orphan(tmpdir):
-    target_parent = tmpdir.mkdir('parent')
-    target_dir = os.path.join(str(target_parent), 'child_1', 'child_2', 'target')
-    target_file = os.path.join(target_dir, 'file')
+    target_parent = tmpdir.mkdir("parent")
+    target_dir = os.path.join(str(target_parent), "child_1", "child_2", "target")
+    target_file = os.path.join(target_dir, "file")
     assert not os.path.exists(target_dir)
     io_handling._ensure_dir_exists(target_file)
     assert os.path.isdir(target_dir)
 
 
 def test_ensure_dir_exists_current_directory(patch_makedirs):
-    io_handling._ensure_dir_exists('filename')
+    io_handling._ensure_dir_exists("filename")
     assert not patch_makedirs.called
 
 
-@pytest.mark.parametrize('should_base64', (True, False))
+@pytest.mark.parametrize("should_base64", (True, False))
 def test_encoder(mocker, should_base64):
-    mocker.patch.object(io_handling, 'Base64IO')
+    mocker.patch.object(io_handling, "Base64IO")
 
     test = io_handling._encoder(sentinel.stream, should_base64)
 
@@ -175,15 +175,18 @@ def test_iohandler_attrs_good():
     io_handling.IOHandler(**GOOD_IOHANDLER_KWARGS)
 
 
-@pytest.mark.parametrize('kwargs', (
-    dict(metadata_writer='not a MetadataWriter'),
-    dict(interactive='not a bool'),
-    dict(no_overwrite='not a bool'),
-    dict(decode_input='not a bool'),
-    dict(encode_output='not a bool'),
-    dict(encryption_context='not a dict'),
-    dict(required_encryption_context_keys='not a list')
-))
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        dict(metadata_writer="not a MetadataWriter"),
+        dict(interactive="not a bool"),
+        dict(no_overwrite="not a bool"),
+        dict(decode_input="not a bool"),
+        dict(encode_output="not a bool"),
+        dict(encryption_context="not a dict"),
+        dict(required_encryption_context_keys="not a list"),
+    ),
+)
 def test_iohandler_attrs_fail(kwargs):
     _kwargs = GOOD_IOHANDLER_KWARGS.copy()
     _kwargs.update(kwargs)
@@ -193,175 +196,122 @@ def test_iohandler_attrs_fail(kwargs):
 
 
 def test_single_io_write_stream_encrypt(
-        tmpdir,
-        patch_aws_encryption_sdk_stream,
-        patch_json_ready_header,
-        patch_json_ready_header_auth,
-        standard_handler
+    tmpdir, patch_aws_encryption_sdk_stream, patch_json_ready_header, patch_json_ready_header_auth, standard_handler
 ):
     patch_aws_encryption_sdk_stream.return_value = io.BytesIO(DATA)
     patch_aws_encryption_sdk_stream.return_value.header = MagicMock()
-    target_file = tmpdir.join('target')
+    target_file = tmpdir.join("target")
     mock_source = MagicMock()
     standard_handler.metadata_writer = MagicMock()
-    with open(str(target_file), 'wb') as destination_writer:
+    with open(str(target_file), "wb") as destination_writer:
         standard_handler._single_io_write(
-            stream_args={
-                'mode': 'encrypt',
-                'a': sentinel.a,
-                'b': sentinel.b
-            },
+            stream_args={"mode": "encrypt", "a": sentinel.a, "b": sentinel.b},
             source=mock_source,
-            destination_writer=destination_writer
+            destination_writer=destination_writer,
         )
 
     patch_aws_encryption_sdk_stream.assert_called_once_with(
-        mode='encrypt',
-        source=mock_source.__enter__.return_value,
-        a=sentinel.a,
-        b=sentinel.b
+        mode="encrypt", source=mock_source.__enter__.return_value, a=sentinel.a, b=sentinel.b
     )
     patch_json_ready_header.assert_called_once_with(patch_aws_encryption_sdk_stream.return_value.header)
     assert not patch_json_ready_header_auth.called
     standard_handler.metadata_writer.__enter__.return_value.write_metadata.assert_called_once_with(
-        mode='encrypt',
+        mode="encrypt",
         input=mock_source.name,
         output=destination_writer.name,
-        header=patch_json_ready_header.return_value
+        header=patch_json_ready_header.return_value,
     )
-    assert target_file.read('rb') == DATA
+    assert target_file.read("rb") == DATA
 
 
 def test_single_io_write_stream_decrypt(
-        tmpdir,
-        patch_aws_encryption_sdk_stream,
-        patch_json_ready_header,
-        patch_json_ready_header_auth,
-        standard_handler
+    tmpdir, patch_aws_encryption_sdk_stream, patch_json_ready_header, patch_json_ready_header_auth, standard_handler
 ):
     patch_aws_encryption_sdk_stream.return_value = io.BytesIO(DATA)
     patch_aws_encryption_sdk_stream.return_value.header = MagicMock()
     patch_aws_encryption_sdk_stream.return_value.header_auth = MagicMock()
-    target_file = tmpdir.join('target')
+    target_file = tmpdir.join("target")
     mock_source = MagicMock()
     standard_handler.metadata_writer = MagicMock()
-    with open(str(target_file), 'wb') as destination_writer:
+    with open(str(target_file), "wb") as destination_writer:
         standard_handler._single_io_write(
-            stream_args={
-                'mode': 'decrypt',
-                'a': sentinel.a,
-                'b': sentinel.b
-            },
+            stream_args={"mode": "decrypt", "a": sentinel.a, "b": sentinel.b},
             source=mock_source,
-            destination_writer=destination_writer
+            destination_writer=destination_writer,
         )
     patch_json_ready_header_auth.assert_called_once_with(patch_aws_encryption_sdk_stream.return_value.header_auth)
     standard_handler.metadata_writer.__enter__.return_value.write_metadata.assert_called_once_with(
-        mode='decrypt',
+        mode="decrypt",
         input=mock_source.name,
         output=destination_writer.name,
         header=patch_json_ready_header.return_value,
-        header_auth=patch_json_ready_header_auth.return_value
+        header_auth=patch_json_ready_header_auth.return_value,
     )
 
 
 def test_single_io_write_stream_encode_output(
-        tmpdir,
-        patch_aws_encryption_sdk_stream,
-        patch_json_ready_header,
-        patch_json_ready_header_auth
+    tmpdir, patch_aws_encryption_sdk_stream, patch_json_ready_header, patch_json_ready_header_auth
 ):
     patch_aws_encryption_sdk_stream.return_value = io.BytesIO(DATA)
     patch_aws_encryption_sdk_stream.return_value.header = MagicMock(encryption_context=sentinel.encryption_context)
-    target_file = tmpdir.join('target')
+    target_file = tmpdir.join("target")
     mock_source = MagicMock()
     kwargs = GOOD_IOHANDLER_KWARGS.copy()
-    kwargs['encode_output'] = True
+    kwargs["encode_output"] = True
     handler = io_handling.IOHandler(**kwargs)
-    with open(str(target_file), 'wb') as destination_writer:
+    with open(str(target_file), "wb") as destination_writer:
         handler._single_io_write(
-            stream_args={
-                'mode': 'encrypt',
-                'a': sentinel.a,
-                'b': sentinel.b
-            },
+            stream_args={"mode": "encrypt", "a": sentinel.a, "b": sentinel.b},
             source=mock_source,
-            destination_writer=destination_writer
+            destination_writer=destination_writer,
         )
 
-    assert target_file.read('rb') == base64.b64encode(DATA)
+    assert target_file.read("rb") == base64.b64encode(DATA)
 
 
-def test_process_single_operation_stdout(
-        patch_for_process_single_operation,
-        patch_should_write_file,
-        standard_handler
-):
-    standard_handler.process_single_operation(
-        stream_args=sentinel.stream_args,
-        source=sentinel.source,
-        destination='-'
-    )
+def test_process_single_operation_stdout(patch_for_process_single_operation, patch_should_write_file, standard_handler):
+    standard_handler.process_single_operation(stream_args=sentinel.stream_args, source=sentinel.source, destination="-")
     io_handling.IOHandler._single_io_write.assert_called_once_with(
-        stream_args=sentinel.stream_args,
-        source=sentinel.source,
-        destination_writer=io_handling._stdout.return_value
+        stream_args=sentinel.stream_args, source=sentinel.source, destination_writer=io_handling._stdout.return_value
     )
     assert not patch_should_write_file.called
 
 
 def test_process_single_operation_stdin_stdout(
-        patch_for_process_single_operation,
-        patch_should_write_file,
-        standard_handler
+    patch_for_process_single_operation, patch_should_write_file, standard_handler
 ):
-    standard_handler.process_single_operation(
-        stream_args=sentinel.stream_args,
-        source='-',
-        destination='-'
-    )
+    standard_handler.process_single_operation(stream_args=sentinel.stream_args, source="-", destination="-")
     io_handling.IOHandler._single_io_write.assert_called_once_with(
         stream_args=sentinel.stream_args,
         source=io_handling._stdin.return_value,
-        destination_writer=io_handling._stdout.return_value
+        destination_writer=io_handling._stdout.return_value,
     )
 
 
 def test_process_single_operation_file(
-        tmpdir,
-        patch_for_process_single_operation,
-        patch_should_write_file,
-        standard_handler
+    tmpdir, patch_for_process_single_operation, patch_should_write_file, standard_handler
 ):
-    destination = tmpdir.join('destination')
+    destination = tmpdir.join("destination")
     with tmpdir.as_cwd():
-        with patch('aws_encryption_sdk_cli.internal.io_handling.open', create=True) as mock_open:
+        with patch("aws_encryption_sdk_cli.internal.io_handling.open", create=True) as mock_open:
             standard_handler.process_single_operation(
-                stream_args=sentinel.stream_args,
-                source=sentinel.source,
-                destination='destination'
+                stream_args=sentinel.stream_args, source=sentinel.source, destination="destination"
             )
-    io_handling._ensure_dir_exists.assert_called_once_with('destination')
-    patch_should_write_file.assert_called_once_with('destination')
-    mock_open.assert_called_once_with(str(destination), 'wb')
+    io_handling._ensure_dir_exists.assert_called_once_with("destination")
+    patch_should_write_file.assert_called_once_with("destination")
+    mock_open.assert_called_once_with(str(destination), "wb")
     io_handling.IOHandler._single_io_write.assert_called_once_with(
-        stream_args=sentinel.stream_args,
-        source=sentinel.source,
-        destination_writer=mock_open.return_value
+        stream_args=sentinel.stream_args, source=sentinel.source, destination_writer=mock_open.return_value
     )
 
 
 def test_process_single_operation_file_should_not_write(
-        patch_for_process_single_operation,
-        patch_should_write_file,
-        standard_handler
+    patch_for_process_single_operation, patch_should_write_file, standard_handler
 ):
     patch_should_write_file.return_value = False
-    with patch('aws_encryption_sdk_cli.internal.io_handling.open', create=True) as mock_open:
+    with patch("aws_encryption_sdk_cli.internal.io_handling.open", create=True) as mock_open:
         standard_handler.process_single_operation(
-            stream_args=sentinel.stream_args,
-            source=sentinel.source,
-            destination=sentinel.destination_file
+            stream_args=sentinel.stream_args, source=sentinel.source, destination=sentinel.destination_file
         )
     assert not io_handling._ensure_dir_exists.called
     assert not mock_open.called
@@ -369,44 +319,36 @@ def test_process_single_operation_file_should_not_write(
 
 
 @pytest.mark.functional
-@pytest.mark.parametrize('interactive, no_overwrite', (
-    (False, False),
-    (False, True),
-    (True, False),
-    (True, True)
-))
+@pytest.mark.parametrize("interactive, no_overwrite", ((False, False), (False, True), (True, False), (True, True)))
 def test_f_should_write_file_does_not_exist(tmpdir, interactive, no_overwrite):
-    target = tmpdir.join('target')
+    target = tmpdir.join("target")
     assert not os.path.exists(str(target))
     # Should always be true regardless of input if file does not exist
     kwargs = GOOD_IOHANDLER_KWARGS.copy()
-    kwargs.update(dict(
-        interactive=interactive,
-        no_overwrite=no_overwrite
-    ))
+    kwargs.update(dict(interactive=interactive, no_overwrite=no_overwrite))
     handler = io_handling.IOHandler(**kwargs)
 
     assert handler._should_write_file(str(target))
 
 
-@pytest.mark.parametrize('interactive, no_overwrite, user_input, expected', (
-    (False, True, None, False),  # no_overwrite is set
-    (True, True, None, False),  # both interactive and no_overwrite are set
-    (True, False, 'y', True),  # interactive is set, and approval input is provided
-    (True, False, 'Y', True),  # interactive is set, and approval input is provided
-    (True, False, 'n', False),  # interactive is set, and approval input is not provided
-    (True, False, '', False),  # interactive is set, and no input is provided,
-    (False, False, None, True)  # interactive is not set, and no_overwrite is not set
-))
+@pytest.mark.parametrize(
+    "interactive, no_overwrite, user_input, expected",
+    (
+        (False, True, None, False),  # no_overwrite is set
+        (True, True, None, False),  # both interactive and no_overwrite are set
+        (True, False, "y", True),  # interactive is set, and approval input is provided
+        (True, False, "Y", True),  # interactive is set, and approval input is provided
+        (True, False, "n", False),  # interactive is set, and approval input is not provided
+        (True, False, "", False),  # interactive is set, and no input is provided,
+        (False, False, None, True),  # interactive is not set, and no_overwrite is not set
+    ),
+)
 def test_should_write_file_does_exist(tmpdir, patch_input, interactive, no_overwrite, user_input, expected):
-    target_file = tmpdir.join('target')
-    target_file.write(b'')
+    target_file = tmpdir.join("target")
+    target_file.write(b"")
     patch_input.return_value = user_input
     kwargs = GOOD_IOHANDLER_KWARGS.copy()
-    kwargs.update(dict(
-        interactive=interactive,
-        no_overwrite=no_overwrite
-    ))
+    kwargs.update(dict(interactive=interactive, no_overwrite=no_overwrite))
     handler = io_handling.IOHandler(**kwargs)
 
     should_write = handler._should_write_file(str(target_file))
@@ -417,86 +359,62 @@ def test_should_write_file_does_exist(tmpdir, patch_input, interactive, no_overw
         assert not should_write
 
 
-@pytest.mark.parametrize('mode, decode_input, encode_output, expected_multiplier', (
-    ('encrypt', False, False, 1.0),
-    ('encrypt', True, False, 0.75),
-    ('encrypt', False, True, 1.0),
-    ('encrypt', True, True, 1.0),
-    ('decrypt', False, False, 1.0),
-    ('decrypt', True, False, 0.75),
-    ('decrypt', False, True, 1.0),
-    ('decrypt', True, True, 1.0)
-))
+@pytest.mark.parametrize(
+    "mode, decode_input, encode_output, expected_multiplier",
+    (
+        ("encrypt", False, False, 1.0),
+        ("encrypt", True, False, 0.75),
+        ("encrypt", False, True, 1.0),
+        ("encrypt", True, True, 1.0),
+        ("decrypt", False, False, 1.0),
+        ("decrypt", True, False, 0.75),
+        ("decrypt", False, True, 1.0),
+        ("decrypt", True, True, 1.0),
+    ),
+)
 def test_process_single_file(
-        tmpdir,
-        patch_process_single_operation,
-        mode,
-        decode_input,
-        encode_output,
-        expected_multiplier
+    tmpdir, patch_process_single_operation, mode, decode_input, encode_output, expected_multiplier
 ):
     patch_process_single_operation.return_value = identifiers.OperationResult.SUCCESS
-    source = tmpdir.join('source')
-    source.write('some data')
+    source = tmpdir.join("source")
+    source.write("some data")
     kwargs = GOOD_IOHANDLER_KWARGS.copy()
-    kwargs.update(dict(
-        decode_input=decode_input,
-        encode_output=encode_output
-    ))
+    kwargs.update(dict(decode_input=decode_input, encode_output=encode_output))
     handler = io_handling.IOHandler(**kwargs)
-    destination = tmpdir.join('destination')
-    initial_kwargs = dict(
-        mode=mode,
-        a=sentinel.a,
-        b=sentinel.b
-    )
+    destination = tmpdir.join("destination")
+    initial_kwargs = dict(mode=mode, a=sentinel.a, b=sentinel.b)
     expected_length = int(os.path.getsize(str(source)) * expected_multiplier)
-    updated_kwargs = dict(
-        mode=mode,
-        a=sentinel.a,
-        b=sentinel.b,
-        source_length=expected_length
-    )
-    with patch('aws_encryption_sdk_cli.internal.io_handling.open', create=True) as mock_open:
-        handler.process_single_file(
-            stream_args=initial_kwargs,
-            source=str(source),
-            destination=str(destination)
-        )
-    mock_open.assert_called_once_with(str(source), 'rb')
+    updated_kwargs = dict(mode=mode, a=sentinel.a, b=sentinel.b, source_length=expected_length)
+    with patch("aws_encryption_sdk_cli.internal.io_handling.open", create=True) as mock_open:
+        handler.process_single_file(stream_args=initial_kwargs, source=str(source), destination=str(destination))
+    mock_open.assert_called_once_with(str(source), "rb")
     patch_process_single_operation.assert_called_once_with(
-        stream_args=updated_kwargs,
-        source=mock_open.return_value.__enter__.return_value,
-        destination=str(destination)
+        stream_args=updated_kwargs, source=mock_open.return_value.__enter__.return_value, destination=str(destination)
     )
 
 
 def test_process_single_file_unknown_error(tmpdir, patch_single_io_write, standard_handler):
-    patch_single_io_write.side_effect = Exception('This is an unknown exception!')
-    source = tmpdir.join('source')
-    source.write('some data')
-    destination = tmpdir.join('destination')
+    patch_single_io_write.side_effect = Exception("This is an unknown exception!")
+    source = tmpdir.join("source")
+    source.write("some data")
+    destination = tmpdir.join("destination")
 
     with pytest.raises(Exception) as excinfo:
         standard_handler.process_single_file(
-            stream_args={'mode': 'encrypt'},
-            source=str(source),
-            destination=str(destination)
+            stream_args={"mode": "encrypt"}, source=str(source), destination=str(destination)
         )
 
-    excinfo.match(r'This is an unknown exception!')
+    excinfo.match(r"This is an unknown exception!")
     assert not destination.isfile()
 
 
 def test_process_single_file_source_is_destination(tmpdir, patch_process_single_operation, standard_handler):
-    source = tmpdir.join('source')
-    source.write('some data')
+    source = tmpdir.join("source")
+    source.write("some data")
 
-    with patch('aws_encryption_sdk_cli.internal.io_handling.open', create=True) as mock_open:
+    with patch("aws_encryption_sdk_cli.internal.io_handling.open", create=True) as mock_open:
         standard_handler.process_single_file(
-            stream_args=sentinel.stream_args,
-            source=str(source),
-            destination=str(source)
+            stream_args=sentinel.stream_args, source=str(source), destination=str(source)
         )
 
     assert not mock_open.called
@@ -504,21 +422,15 @@ def test_process_single_file_source_is_destination(tmpdir, patch_process_single_
 
 
 @pytest.mark.skipif(is_windows(), reason=WINDOWS_SKIP_MESSAGE)
-def test_process_single_file_destination_is_symlink_to_source(
-        tmpdir,
-        patch_process_single_operation,
-        standard_handler
-):
-    source = tmpdir.join('source')
-    source.write('some data')
-    destination = str(tmpdir.join('destination'))
+def test_process_single_file_destination_is_symlink_to_source(tmpdir, patch_process_single_operation, standard_handler):
+    source = tmpdir.join("source")
+    source.write("some data")
+    destination = str(tmpdir.join("destination"))
     os.symlink(str(source), destination)
 
-    with patch('aws_encryption_sdk_cli.internal.io_handling.open', create=True) as mock_open:
+    with patch("aws_encryption_sdk_cli.internal.io_handling.open", create=True) as mock_open:
         standard_handler.process_single_file(
-            stream_args=sentinel.stream_args,
-            source=str(source),
-            destination=destination
+            stream_args=sentinel.stream_args, source=str(source), destination=destination
         )
 
     assert not mock_open.called
@@ -526,100 +438,101 @@ def test_process_single_file_destination_is_symlink_to_source(
 
 
 def test_process_single_file_failed_and_destination_does_not_exist(
-        tmpdir,
-        patch_process_single_operation,
-        patch_os_remove,
-        standard_handler
+    tmpdir, patch_process_single_operation, patch_os_remove, standard_handler
 ):
     patch_process_single_operation.return_value = identifiers.OperationResult.FAILED
     patch_os_remove.side_effect = OSError
-    source = tmpdir.join('source')
-    source.write('some data')
-    destination = tmpdir.join('destination')
+    source = tmpdir.join("source")
+    source.write("some data")
+    destination = tmpdir.join("destination")
 
     # Verify that nothing is raised when os.remove raises an OSError
     standard_handler.process_single_file(
-        stream_args={'mode': 'encrypt'},
-        source=str(source),
-        destination=str(destination)
+        stream_args={"mode": "encrypt"}, source=str(source), destination=str(destination)
     )
 
 
-@pytest.mark.parametrize('source, destination, mode, suffix, output', (
+@pytest.mark.parametrize(
+    "source, destination, mode, suffix, output",
     (
-        os.path.join('source_dir', 'source_filename'),
-        'destination_dir',
-        'encrypt',
-        None,
-        os.path.join('destination_dir', 'source_filename.encrypted')
+        (
+            os.path.join("source_dir", "source_filename"),
+            "destination_dir",
+            "encrypt",
+            None,
+            os.path.join("destination_dir", "source_filename.encrypted"),
+        ),
+        (
+            os.path.join("source_dir", "source_filename.encrypted"),
+            "destination_dir",
+            "encrypt",
+            None,
+            os.path.join("destination_dir", "source_filename.encrypted.encrypted"),
+        ),
+        (
+            os.path.join("source_dir", "source_filename"),
+            "destination_dir",
+            "decrypt",
+            None,
+            os.path.join("destination_dir", "source_filename.decrypted"),
+        ),
+        (
+            os.path.join("source_dir", "source_filename.encrypted"),
+            "destination_dir",
+            "decrypt",
+            None,
+            os.path.join("destination_dir", "source_filename.encrypted.decrypted"),
+        ),
+        (
+            os.path.join("source_dir", "source_filename"),
+            "destination_dir",
+            "encrypt",
+            "CUSTOM_SUFFIX",
+            os.path.join("destination_dir", "source_filenameCUSTOM_SUFFIX"),
+        ),
+        (
+            os.path.join("source_dir", "source_filename"),
+            "destination_dir",
+            "decrypt",
+            "CUSTOM_SUFFIX",
+            os.path.join("destination_dir", "source_filenameCUSTOM_SUFFIX"),
+        ),
     ),
-    (
-        os.path.join('source_dir', 'source_filename.encrypted'),
-        'destination_dir',
-        'encrypt',
-        None,
-        os.path.join('destination_dir', 'source_filename.encrypted.encrypted')
-    ),
-    (
-        os.path.join('source_dir', 'source_filename'),
-        'destination_dir',
-        'decrypt',
-        None,
-        os.path.join('destination_dir', 'source_filename.decrypted')
-    ),
-    (
-        os.path.join('source_dir', 'source_filename.encrypted'),
-        'destination_dir',
-        'decrypt',
-        None,
-        os.path.join('destination_dir', 'source_filename.encrypted.decrypted')
-    ),
-    (
-        os.path.join('source_dir', 'source_filename'),
-        'destination_dir',
-        'encrypt',
-        'CUSTOM_SUFFIX',
-        os.path.join('destination_dir', 'source_filenameCUSTOM_SUFFIX')
-    ),
-    (
-        os.path.join('source_dir', 'source_filename'),
-        'destination_dir',
-        'decrypt',
-        'CUSTOM_SUFFIX',
-        os.path.join('destination_dir', 'source_filenameCUSTOM_SUFFIX')
-    )
-))
+)
 def test_output_filename(source, destination, mode, suffix, output):
     assert io_handling.output_filename(source, destination, mode, suffix) == output
 
 
-@pytest.mark.parametrize('source_root, destination_root, source_dir, output', (
+@pytest.mark.parametrize(
+    "source_root, destination_root, source_dir, output",
     (
-        'source_dir',
-        'destination_dir',
-        os.path.join('source_dir', 'child_1'),
-        os.path.join('destination_dir', 'child_1')
+        (
+            "source_dir",
+            "destination_dir",
+            os.path.join("source_dir", "child_1"),
+            os.path.join("destination_dir", "child_1"),
+        ),
+        (
+            "source_dir",
+            "destination_dir",
+            os.path.join("source_dir", "child_1", "child_2", "child_3"),
+            os.path.join("destination_dir", "child_1", "child_2", "child_3"),
+        ),
+        (
+            os.path.join("source_dir", "actual_source_root"),
+            "destination_dir",
+            os.path.join("source_dir", "actual_source_root", "child_1"),
+            os.path.join("destination_dir", "child_1"),
+        ),
     ),
-    (
-        'source_dir',
-        'destination_dir',
-        os.path.join('source_dir', 'child_1', 'child_2', 'child_3'),
-        os.path.join('destination_dir', 'child_1', 'child_2', 'child_3')
-    ),
-    (
-        os.path.join('source_dir', 'actual_source_root'),
-        'destination_dir',
-        os.path.join('source_dir', 'actual_source_root', 'child_1'),
-        os.path.join('destination_dir', 'child_1')
-    )
-))
+)
 def test_output_dir(source_root, destination_root, source_dir, output):
     assert io_handling._output_dir(source_root, destination_root, source_dir) == output
 
 
 def _mock_aws_encryption_sdk_stream_output(source, *args, **kwargs):
     source_filename = source.name
-    suffix = source_filename.rsplit('_', 1)[-1]
+    suffix = source_filename.rsplit("_", 1)[-1]
     mock_stream = io.BytesIO(DATA + six.b(suffix))
     mock_stream.header = MagicMock(encryption_context=sentinel.encryption_context)
     return mock_stream
@@ -627,36 +540,33 @@ def _mock_aws_encryption_sdk_stream_output(source, *args, **kwargs):
 
 def test_process_dir(tmpdir, patch_aws_encryption_sdk_stream, patch_json_ready_header, standard_handler):
     patch_aws_encryption_sdk_stream.side_effect = _mock_aws_encryption_sdk_stream_output
-    source = tmpdir.mkdir('source')
-    source.mkdir('a')
-    source.join('a', 'target_a1').write(b'')
-    source.join('a', 'target_a2').write(b'')
-    b_dir = source.mkdir('b')
-    source.join('b', 'target_b1').write(b'')
-    source.join('b', 'target_b2').write(b'')
-    c_dir = b_dir.mkdir('c')
-    b_dir.join('c', 'target_c1').write(b'')
-    b_dir.join('c', 'target_c2').write(b'')
-    e_dir = c_dir.mkdir('d').mkdir('e')
-    e_dir.join('target_e1').write(b'')
-    target = tmpdir.mkdir('target')
+    source = tmpdir.mkdir("source")
+    source.mkdir("a")
+    source.join("a", "target_a1").write(b"")
+    source.join("a", "target_a2").write(b"")
+    b_dir = source.mkdir("b")
+    source.join("b", "target_b1").write(b"")
+    source.join("b", "target_b2").write(b"")
+    c_dir = b_dir.mkdir("c")
+    b_dir.join("c", "target_c1").write(b"")
+    b_dir.join("c", "target_c2").write(b"")
+    e_dir = c_dir.mkdir("d").mkdir("e")
+    e_dir.join("target_e1").write(b"")
+    target = tmpdir.mkdir("target")
 
     standard_handler.process_dir(
-        stream_args={'mode': 'encrypt'},
-        source=str(source),
-        destination=str(target),
-        suffix=None
+        stream_args={"mode": "encrypt"}, source=str(source), destination=str(target), suffix=None
     )
 
     for filename, suffix in (
-            (os.path.join(str(target), 'a', 'target_a1.encrypted'), b'a1'),
-            (os.path.join(str(target), 'a', 'target_a2.encrypted'), b'a2'),
-            (os.path.join(str(target), 'b', 'target_b1.encrypted'), b'b1'),
-            (os.path.join(str(target), 'b', 'target_b2.encrypted'), b'b2'),
-            (os.path.join(str(target), 'b', 'c', 'target_c1.encrypted'), b'c1'),
-            (os.path.join(str(target), 'b', 'c', 'target_c2.encrypted'), b'c2'),
-            (os.path.join(str(target), 'b', 'c', 'd', 'e', 'target_e1.encrypted'), b'e1')
+        (os.path.join(str(target), "a", "target_a1.encrypted"), b"a1"),
+        (os.path.join(str(target), "a", "target_a2.encrypted"), b"a2"),
+        (os.path.join(str(target), "b", "target_b1.encrypted"), b"b1"),
+        (os.path.join(str(target), "b", "target_b2.encrypted"), b"b2"),
+        (os.path.join(str(target), "b", "c", "target_c1.encrypted"), b"c1"),
+        (os.path.join(str(target), "b", "c", "target_c2.encrypted"), b"c2"),
+        (os.path.join(str(target), "b", "c", "d", "e", "target_e1.encrypted"), b"e1"),
     ):
         assert os.path.isfile(filename)
-        with open(filename, 'rb') as f:
+        with open(filename, "rb") as f:
             assert f.read() == DATA + suffix

--- a/test/unit/test_io_handling.py
+++ b/test/unit/test_io_handling.py
@@ -16,13 +16,14 @@ import io
 import os
 import sys
 
-from mock import MagicMock, patch, sentinel
 import pytest
-from pytest_mock import mocker  # noqa pylint: disable=unused-import
 import six
+from mock import MagicMock, patch, sentinel
+from pytest_mock import mocker  # noqa pylint: disable=unused-import
 
 from aws_encryption_sdk_cli.internal import identifiers, io_handling, metadata
-from .unit_test_utils import is_windows, WINDOWS_SKIP_MESSAGE
+
+from .unit_test_utils import WINDOWS_SKIP_MESSAGE, is_windows
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 DATA = b'aosidhjf9aiwhj3f98wiaj49c8a3hj49f8uwa0edifja9w843hj98'

--- a/test/unit/test_key_providers.py
+++ b/test/unit/test_key_providers.py
@@ -11,8 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Unit test suite for ``aws_encryption_sdk_cli.key_providers``."""
-from mock import sentinel
 import pytest
+from mock import sentinel
 from pytest_mock import mocker  # noqa pylint: disable=unused-import
 
 from aws_encryption_sdk_cli import key_providers

--- a/test/unit/test_key_providers.py
+++ b/test/unit/test_key_providers.py
@@ -24,51 +24,55 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 @pytest.yield_fixture
 def patch_deepcopy(mocker):
-    mocker.patch.object(key_providers.copy, 'deepcopy')
+    mocker.patch.object(key_providers.copy, "deepcopy")
     yield key_providers.copy.deepcopy
 
 
 @pytest.yield_fixture
 def patch_botocore_session(mocker):
-    mocker.patch.object(key_providers.botocore.session, 'Session')
+    mocker.patch.object(key_providers.botocore.session, "Session")
     key_providers.botocore.session.Session.return_value = sentinel.botocore_session
     yield key_providers.botocore.session.Session
 
 
 @pytest.yield_fixture
 def patch_kms_master_key_provider(mocker):
-    mocker.patch.object(key_providers, 'KMSMasterKeyProvider')
+    mocker.patch.object(key_providers, "KMSMasterKeyProvider")
     yield key_providers.KMSMasterKeyProvider
 
 
-@pytest.mark.parametrize('source, expected', (
-    ({}, {'botocore_session': sentinel.botocore_session}),  # empty baseline
-    (  # arbitrary non-empty baseline
-        {'a': 'a thing', 'b': 'another thing'},
-        {'a': 'a thing', 'b': 'another thing', 'botocore_session': sentinel.botocore_session}
+@pytest.mark.parametrize(
+    "source, expected",
+    (
+        ({}, {"botocore_session": sentinel.botocore_session}),  # empty baseline
+        (  # arbitrary non-empty baseline
+            {"a": "a thing", "b": "another thing"},
+            {"a": "a thing", "b": "another thing", "botocore_session": sentinel.botocore_session},
+        ),
+        (  # region_names without region
+            {"a": "a thing", "region_names": ["us-east-2", "ca-central-1"]},
+            {
+                "a": "a thing",
+                "region_names": ["us-east-2", "ca-central-1"],
+                "botocore_session": sentinel.botocore_session,
+            },
+        ),
+        (  # region without region_names
+            {"a": "a thing", "region": ["eu-central-1"]},
+            {"a": "a thing", "region_names": ["eu-central-1"], "botocore_session": sentinel.botocore_session},
+        ),
+        (  # region and region_names specified
+            {"a": "a thing", "region_names": ["us-east-2", "ca-central-1"], "region": ["eu-central-1"]},
+            {"a": "a thing", "region_names": ["eu-central-1"], "botocore_session": sentinel.botocore_session},
+        ),
+        (  # profile specified
+            {"a": "a thing", "profile": [sentinel.profile_name]},
+            {"a": "a thing", "botocore_session": sentinel.botocore_session},
+        ),
     ),
-    (  # region_names without region
-        {'a': 'a thing', 'region_names': ['us-east-2', 'ca-central-1']},
-        {'a': 'a thing', 'region_names': ['us-east-2', 'ca-central-1'], 'botocore_session': sentinel.botocore_session}
-    ),
-    (  # region without region_names
-        {'a': 'a thing', 'region': ['eu-central-1']},
-        {'a': 'a thing', 'region_names': ['eu-central-1'], 'botocore_session': sentinel.botocore_session}
-    ),
-    (  # region and region_names specified
-        {'a': 'a thing', 'region_names': ['us-east-2', 'ca-central-1'], 'region': ['eu-central-1']},
-        {'a': 'a thing', 'region_names': ['eu-central-1'], 'botocore_session': sentinel.botocore_session}
-    ),
-    (  # profile specified
-        {'a': 'a thing', 'profile': [sentinel.profile_name]},
-        {'a': 'a thing', 'botocore_session': sentinel.botocore_session}
-    )
-))
+)
 def test_kms_master_key_provider_post_processing(
-        patch_botocore_session,
-        patch_kms_master_key_provider,
-        source,
-        expected
+    patch_botocore_session, patch_kms_master_key_provider, source, expected
 ):
     test = key_providers.aws_kms_master_key_provider(**source)
 
@@ -76,36 +80,30 @@ def test_kms_master_key_provider_post_processing(
     assert test is patch_kms_master_key_provider.return_value
 
 
-def test_kms_master_key_provider_post_processing_named_profile(
-        patch_botocore_session,
-        patch_kms_master_key_provider
-):
-    key_providers.aws_kms_master_key_provider(profile=['a profile name'])
+def test_kms_master_key_provider_post_processing_named_profile(patch_botocore_session, patch_kms_master_key_provider):
+    key_providers.aws_kms_master_key_provider(profile=["a profile name"])
 
-    patch_botocore_session.assert_called_once_with(profile='a profile name')
+    patch_botocore_session.assert_called_once_with(profile="a profile name")
     assert patch_botocore_session.return_value.user_agent_extra == USER_AGENT_SUFFIX
 
 
-def test_kms_master_key_provider_post_processing_default_profile(
-        patch_botocore_session,
-        patch_kms_master_key_provider
-):
+def test_kms_master_key_provider_post_processing_default_profile(patch_botocore_session, patch_kms_master_key_provider):
     key_providers.aws_kms_master_key_provider()
 
     patch_botocore_session.assert_called_once_with(profile=None)
 
 
-@pytest.mark.parametrize('profile_names', ([], [sentinel.a, sentinel.b]))
+@pytest.mark.parametrize("profile_names", ([], [sentinel.a, sentinel.b]))
 def test_kms_master_key_provider_post_processing_not_one_profile(profile_names):
     with pytest.raises(BadUserArgumentError) as excinfo:
         key_providers.aws_kms_master_key_provider(profile=profile_names)
 
-    excinfo.match(r'Only one profile may be specified per master key provider configuration. *')
+    excinfo.match(r"Only one profile may be specified per master key provider configuration. *")
 
 
-@pytest.mark.parametrize('regions', ([], [sentinel.a, sentinel.b]))
+@pytest.mark.parametrize("regions", ([], [sentinel.a, sentinel.b]))
 def test_kms_master_key_provider_post_processing_not_one_region(regions):
     with pytest.raises(BadUserArgumentError) as excinfo:
         key_providers.aws_kms_master_key_provider(region=regions)
 
-    excinfo.match(r'Only one region may be specified per master key provider configuration. *')
+    excinfo.match(r"Only one region may be specified per master key provider configuration. *")

--- a/test/unit/test_logging_utils.py
+++ b/test/unit/test_logging_utils.py
@@ -13,8 +13,8 @@
 """Unit testing suite for ``aws_encryption_sdk_cli.internal.logging``."""
 import logging
 
-from mock import call, MagicMock, sentinel
 import pytest
+from mock import MagicMock, call, sentinel
 
 from aws_encryption_sdk_cli.internal import logging_utils
 

--- a/test/unit/test_logging_utils.py
+++ b/test/unit/test_logging_utils.py
@@ -23,39 +23,42 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 @pytest.yield_fixture
 def patch_logging_levels(mocker):
-    mocker.patch.object(logging_utils, '_logging_levels')
+    mocker.patch.object(logging_utils, "_logging_levels")
     yield logging_utils._logging_levels
 
 
 @pytest.yield_fixture
 def patch_logging(mocker):
-    mocker.patch.object(logging_utils, 'logging')
+    mocker.patch.object(logging_utils, "logging")
     yield logging_utils.logging
 
 
 @pytest.yield_fixture
 def patch_blacklist_filter(mocker):
-    mocker.patch.object(logging_utils, '_BlacklistFilter')
+    mocker.patch.object(logging_utils, "_BlacklistFilter")
     yield logging_utils._BlacklistFilter
 
 
 @pytest.yield_fixture
 def patch_kms_key_redacting_formatter(mocker):
-    mocker.patch.object(logging_utils, '_KMSKeyRedactingFormatter')
+    mocker.patch.object(logging_utils, "_KMSKeyRedactingFormatter")
     yield logging_utils._KMSKeyRedactingFormatter
 
 
-@pytest.mark.parametrize('verbosity, quiet, local_level, root_level', (
-    (None, False, logging.WARNING, logging.CRITICAL),
-    (-1, False, logging.WARNING, logging.CRITICAL),
-    (0, False, logging.WARNING, logging.CRITICAL),
-    (1, False, logging.INFO, logging.CRITICAL),
-    (2, False, logging.DEBUG, logging.CRITICAL),
-    (3, False, logging.DEBUG, logging.INFO),
-    (4, False, logging.DEBUG, logging.DEBUG),
-    (99, False, logging.DEBUG, logging.DEBUG),
-    (99, True, logging.CRITICAL, logging.CRITICAL)
-))
+@pytest.mark.parametrize(
+    "verbosity, quiet, local_level, root_level",
+    (
+        (None, False, logging.WARNING, logging.CRITICAL),
+        (-1, False, logging.WARNING, logging.CRITICAL),
+        (0, False, logging.WARNING, logging.CRITICAL),
+        (1, False, logging.INFO, logging.CRITICAL),
+        (2, False, logging.DEBUG, logging.CRITICAL),
+        (3, False, logging.DEBUG, logging.INFO),
+        (4, False, logging.DEBUG, logging.DEBUG),
+        (99, False, logging.DEBUG, logging.DEBUG),
+        (99, True, logging.CRITICAL, logging.CRITICAL),
+    ),
+)
 def test_logging_utils_levels(verbosity, quiet, local_level, root_level):
     assert logging_utils._logging_levels(verbosity, quiet) == (local_level, root_level)
 
@@ -64,26 +67,17 @@ def test_setup_logger(patch_logging_levels, patch_blacklist_filter, patch_loggin
     patch_logging_levels.return_value = sentinel.local_level, sentinel.root_level
     mock_local_logger = MagicMock()
     mock_root_logger = MagicMock()
-    patch_logging.getLogger.side_effect = (
-        mock_local_logger,
-        mock_root_logger
-    )
+    patch_logging.getLogger.side_effect = (mock_local_logger, mock_root_logger)
     mock_local_handler = MagicMock()
     mock_root_handler = MagicMock()
-    patch_logging.StreamHandler.side_effect = (
-        mock_local_handler,
-        mock_root_handler
-    )
+    patch_logging.StreamHandler.side_effect = (mock_local_handler, mock_root_handler)
     logging_utils.setup_logger(sentinel.verbosity, sentinel.quiet)
 
     patch_logging_levels.assert_called_once_with(sentinel.verbosity, sentinel.quiet)
     patch_kms_key_redacting_formatter.assert_called_once_with(logging_utils.FORMAT_STRING)
     patch_logging.StreamHandler.assert_has_calls(calls=(call(), call()), any_order=True)
     mock_local_handler.setFormatter.assert_called_once_with(patch_kms_key_redacting_formatter.return_value)
-    patch_logging.getLogger.assert_has_calls(
-        calls=(call(logging_utils.LOGGER_NAME), call()),
-        any_order=False
-    )
+    patch_logging.getLogger.assert_has_calls(calls=(call(logging_utils.LOGGER_NAME), call()), any_order=False)
     patch_blacklist_filter.assert_called_once_with(logging_utils.LOGGER_NAME)
     mock_root_handler.setFormatter.assert_called_once_with(patch_kms_key_redacting_formatter.return_value)
     mock_root_handler.addFilter.assert_called_once_with(patch_blacklist_filter.return_value)
@@ -99,6 +93,7 @@ def test_blacklist_filter():
 
         def __init__(self, name):
             self.name = name
+
     test = logging_utils._BlacklistFilter(sentinel.a, sentinel.b)
 
     assert test._BlacklistFilter__blacklist == (sentinel.a, sentinel.b)

--- a/test/unit/test_master_key_parsing.py
+++ b/test/unit/test_master_key_parsing.py
@@ -11,13 +11,13 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Unit test suite for ``aws_encryption_sdk_cli.internal.master_key_parsing``."""
-from collections import defaultdict, namedtuple
 import logging
+from collections import defaultdict, namedtuple
 
-from mock import call, MagicMock, sentinel
 import pytest
-from pytest_mock import mocker  # noqa pylint: disable=unused-import
 import six
+from mock import MagicMock, call, sentinel
+from pytest_mock import mocker  # noqa pylint: disable=unused-import
 
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal import logging_utils, master_key_parsing

--- a/test/unit/test_master_key_parsing.py
+++ b/test/unit/test_master_key_parsing.py
@@ -28,42 +28,39 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 @pytest.yield_fixture
 def patch_load_master_key_provider(mocker):
-    mocker.patch.object(master_key_parsing, '_load_master_key_provider')
+    mocker.patch.object(master_key_parsing, "_load_master_key_provider")
     yield master_key_parsing._load_master_key_provider
 
 
 @pytest.yield_fixture
 def patch_build_master_key_provider(mocker):
-    mocker.patch.object(master_key_parsing, '_build_master_key_provider')
-    master_key_parsing._build_master_key_provider.side_effect = (
-        sentinel.key_provider_1,
-        sentinel.key_provider_2
-    )
+    mocker.patch.object(master_key_parsing, "_build_master_key_provider")
+    master_key_parsing._build_master_key_provider.side_effect = (sentinel.key_provider_1, sentinel.key_provider_2)
     yield master_key_parsing._build_master_key_provider
 
 
 @pytest.yield_fixture
 def patch_assemble_master_key_providers(mocker):
-    mocker.patch.object(master_key_parsing, '_assemble_master_key_providers')
+    mocker.patch.object(master_key_parsing, "_assemble_master_key_providers")
     master_key_parsing._assemble_master_key_providers.return_value = sentinel.assembled_key_providers
     yield master_key_parsing._assemble_master_key_providers
 
 
 @pytest.yield_fixture
 def patch_parse_master_key_providers(mocker):
-    mocker.patch.object(master_key_parsing, '_parse_master_key_providers_from_args')
+    mocker.patch.object(master_key_parsing, "_parse_master_key_providers_from_args")
     yield master_key_parsing._parse_master_key_providers_from_args
 
 
 @pytest.yield_fixture
 def patch_aws_encryption_sdk(mocker):
-    mocker.patch.object(master_key_parsing, 'aws_encryption_sdk')
+    mocker.patch.object(master_key_parsing, "aws_encryption_sdk")
     yield master_key_parsing.aws_encryption_sdk
 
 
 @pytest.yield_fixture
 def patch_iter_entry_points(mocker):
-    mocker.patch.object(master_key_parsing.pkg_resources, 'iter_entry_points')
+    mocker.patch.object(master_key_parsing.pkg_resources, "iter_entry_points")
     yield master_key_parsing.pkg_resources.iter_entry_points
 
 
@@ -87,103 +84,91 @@ def entry_points_cleaner():
 
 
 # "name" is a special, non-overridable attribute on mock objects
-FakeEntryPoint = namedtuple('FakeEntryPoint', ['name', 'module_name', 'attrs', 'extras', 'dist'])
-FakeEntryPoint.__new__.__defaults__ = ('MODULE', 'ATTRS', 'EXTRAS', MagicMock(project_name='PROJECT'))
+FakeEntryPoint = namedtuple("FakeEntryPoint", ["name", "module_name", "attrs", "extras", "dist"])
+FakeEntryPoint.__new__.__defaults__ = ("MODULE", "ATTRS", "EXTRAS", MagicMock(project_name="PROJECT"))
 
 
 def test_entry_points(monkeypatch):
-    monkeypatch.setattr(master_key_parsing, '_ENTRY_POINTS', defaultdict(dict))
+    monkeypatch.setattr(master_key_parsing, "_ENTRY_POINTS", defaultdict(dict))
     test = master_key_parsing._entry_points()
 
     assert test == master_key_parsing._ENTRY_POINTS
 
 
 def test_entry_points_aws_kms():
-    assert master_key_parsing._entry_points()['aws-kms']['aws-encryption-sdk-cli'].load() == aws_kms_master_key_provider
+    assert master_key_parsing._entry_points()["aws-kms"]["aws-encryption-sdk-cli"].load() == aws_kms_master_key_provider
 
 
 def test_entry_points_invalid_substring(logger_stream, patch_iter_entry_points):
-    patch_iter_entry_points.return_value = [FakeEntryPoint('BAD::NAME')]
+    patch_iter_entry_points.return_value = [FakeEntryPoint("BAD::NAME")]
     master_key_parsing._discover_entry_points()
 
     key = 'Invalid substring "::" in discovered entry point "BAD::NAME". It will not be usable.'
     logging_results = logger_stream.getvalue()
     assert key in logging_results
-    assert 'BAD::NAME' not in master_key_parsing._ENTRY_POINTS
+    assert "BAD::NAME" not in master_key_parsing._ENTRY_POINTS
 
 
 def test_entry_points_multiple_per_name(entry_points_cleaner, patch_iter_entry_points):
-    entry_point_a = FakeEntryPoint(name='aws-kms', dist=MagicMock(project_name='aws-encryption-sdk-cli'))
-    entry_point_b = FakeEntryPoint(name='aws-kms', dist=MagicMock(project_name='some-other-thing'))
-    entry_point_c = FakeEntryPoint(name='zzz', dist=MagicMock(project_name='yet-another-thing'))
+    entry_point_a = FakeEntryPoint(name="aws-kms", dist=MagicMock(project_name="aws-encryption-sdk-cli"))
+    entry_point_b = FakeEntryPoint(name="aws-kms", dist=MagicMock(project_name="some-other-thing"))
+    entry_point_c = FakeEntryPoint(name="zzz", dist=MagicMock(project_name="yet-another-thing"))
     patch_iter_entry_points.return_value = [entry_point_a, entry_point_b, entry_point_c]
 
     test = master_key_parsing._entry_points()
 
     assert dict(test) == {
-        'aws-kms': {
-            'aws-encryption-sdk-cli': entry_point_a,
-            'some-other-thing': entry_point_b
-        },
-        'zzz': {'yet-another-thing': entry_point_c}
+        "aws-kms": {"aws-encryption-sdk-cli": entry_point_a, "some-other-thing": entry_point_b},
+        "zzz": {"yet-another-thing": entry_point_c},
     }
 
 
 def test_load_master_key_provider_unknown_name(monkeypatch):
     master_key_parsing._entry_points()
-    monkeypatch.setattr(master_key_parsing, '_ENTRY_POINTS', defaultdict(dict))
+    monkeypatch.setattr(master_key_parsing, "_ENTRY_POINTS", defaultdict(dict))
     with pytest.raises(BadUserArgumentError) as excinfo:
-        master_key_parsing._load_master_key_provider('unknown_name')
+        master_key_parsing._load_master_key_provider("unknown_name")
 
     excinfo.match(r'Requested master key provider not found: "unknown_name"')
 
 
 def test_load_master_key_provider_known_name_only_single_entry_point():
-    assert master_key_parsing._load_master_key_provider('aws-kms') == aws_kms_master_key_provider
+    assert master_key_parsing._load_master_key_provider("aws-kms") == aws_kms_master_key_provider
 
 
 def test_load_master_key_provider_known_name_only_multiple_entry_points(monkeypatch):
     monkeypatch.setitem(
         master_key_parsing._ENTRY_POINTS,
-        'aws-kms',
+        "aws-kms",
         {
-            'aws-encryption-sdk-cli': FakeEntryPoint(
-                name='aws-kms',
-                dist=MagicMock(project_name='aws-encryption-sdk-cli')
+            "aws-encryption-sdk-cli": FakeEntryPoint(
+                name="aws-kms", dist=MagicMock(project_name="aws-encryption-sdk-cli")
             ),
-            'my-fake-package': FakeEntryPoint(
-                name='aws-kms',
-                module_name='my-fake-package'
-            )
-        }
+            "my-fake-package": FakeEntryPoint(name="aws-kms", module_name="my-fake-package"),
+        },
     )
 
     with pytest.raises(BadUserArgumentError) as excinfo:
-        master_key_parsing._load_master_key_provider('aws-kms')
+        master_key_parsing._load_master_key_provider("aws-kms")
 
-    excinfo.match(r'Multiple entry points discovered and no package specified. *')
+    excinfo.match(r"Multiple entry points discovered and no package specified. *")
 
 
 def test_load_master_key_provider_known_package_and_name():
-    assert master_key_parsing._load_master_key_provider(
-        'aws-encryption-sdk-cli::aws-kms'
-    ) == aws_kms_master_key_provider
+    assert (
+        master_key_parsing._load_master_key_provider("aws-encryption-sdk-cli::aws-kms") == aws_kms_master_key_provider
+    )
 
 
 def test_load_master_key_provider_known_name_unknown_name(monkeypatch):
     monkeypatch.setitem(
         master_key_parsing._ENTRY_POINTS,
-        'aws-kms',
-        {
-            'my-fake-package': FakeEntryPoint(
-                name='aws-kms',
-                module_name='my-fake-package'
-            )
-        }
+        "aws-kms",
+        {"my-fake-package": FakeEntryPoint(name="aws-kms", module_name="my-fake-package")},
     )
 
     with pytest.raises(BadUserArgumentError) as excinfo:
-        master_key_parsing._load_master_key_provider('aws-encryption-sdk-cli::aws-kms')
+        master_key_parsing._load_master_key_provider("aws-encryption-sdk-cli::aws-kms")
 
     excinfo.match(
         r'Requested master key provider not found: "aws-encryption-sdk-cli::aws-kms". Packages discovered for *'
@@ -194,10 +179,7 @@ def test_build_master_key_provider_known_provider(patch_load_master_key_provider
     mock_provider_callable = MagicMock()
     patch_load_master_key_provider.return_value = mock_provider_callable
     test = master_key_parsing._build_master_key_provider(
-        provider=sentinel.known_provider_id,
-        key=[],
-        a=sentinel.a,
-        b=sentinel.b
+        provider=sentinel.known_provider_id, key=[], a=sentinel.a, b=sentinel.b
     )
     patch_load_master_key_provider.assert_called_once_with(sentinel.known_provider_id)
     mock_provider_callable.assert_called_once_with(a=sentinel.a, b=sentinel.b)
@@ -209,74 +191,49 @@ def test_build_master_key_provider_add_keys(patch_load_master_key_provider):
     mock_provider = MagicMock()
     patch_load_master_key_provider.return_value.return_value = mock_provider
     master_key_parsing._build_master_key_provider(
-        provider=sentinel.unknown_provider_id,
-        key=[
-            sentinel.key_id_1,
-            sentinel.key_id_2
-        ]
+        provider=sentinel.unknown_provider_id, key=[sentinel.key_id_1, sentinel.key_id_2]
     )
     mock_provider.add_master_key.assert_has_calls(
-        calls=(
-            call(sentinel.key_id_1),
-            call(sentinel.key_id_2)
-        ),
-        any_order=False
+        calls=(call(sentinel.key_id_1), call(sentinel.key_id_2)), any_order=False
     )
 
 
 def test_build_master_key_provider_additional_kwargs(patch_load_master_key_provider):
-    kwargs = {'a': 1, 'b': 'asdf'}
-    master_key_parsing._build_master_key_provider(
-        provider=sentinel.unknown_provider_id,
-        key=[],
-        **kwargs
-    )
+    kwargs = {"a": 1, "b": "asdf"}
+    master_key_parsing._build_master_key_provider(provider=sentinel.unknown_provider_id, key=[], **kwargs)
     patch_load_master_key_provider.return_value.assert_called_once_with(**kwargs)
 
 
 def test_assemble_master_key_providers():
     mock_primary = MagicMock()
-    test = master_key_parsing._assemble_master_key_providers(
-        mock_primary,
-        sentinel.provider_1,
-        sentinel.provider_2
-    )
+    test = master_key_parsing._assemble_master_key_providers(mock_primary, sentinel.provider_1, sentinel.provider_2)
     mock_primary.add_master_key_provider.assert_has_calls(
-        calls=(
-            call(sentinel.provider_1),
-            call(sentinel.provider_2)
-        ),
-        any_order=False
+        calls=(call(sentinel.provider_1), call(sentinel.provider_2)), any_order=False
     )
     assert test is mock_primary
 
 
 def test_parse_master_key_providers_from_args(patch_build_master_key_provider, patch_assemble_master_key_providers):
     test = master_key_parsing._parse_master_key_providers_from_args(
-        {'provider': 'provider_1_a', 'key': ['provider_info_1_b']},
-        {'provider': 'provider_2_a', 'key': ['provider_info_2_b'], 'z': 'additional_z'}
+        {"provider": "provider_1_a", "key": ["provider_info_1_b"]},
+        {"provider": "provider_2_a", "key": ["provider_info_2_b"], "z": "additional_z"},
     )
     patch_build_master_key_provider.assert_has_calls(
         calls=(
-            call(provider='provider_1_a', key=['provider_info_1_b']),
-            call(provider='provider_2_a', key=['provider_info_2_b'], z='additional_z')
+            call(provider="provider_1_a", key=["provider_info_1_b"]),
+            call(provider="provider_2_a", key=["provider_info_2_b"], z="additional_z"),
         ),
-        any_order=False
+        any_order=False,
     )
-    patch_assemble_master_key_providers.assert_called_once_with(
-        sentinel.key_provider_1,
-        sentinel.key_provider_2
-    )
+    patch_assemble_master_key_providers.assert_called_once_with(sentinel.key_provider_1, sentinel.key_provider_2)
     assert test is sentinel.assembled_key_providers
 
 
 def test_build_crypto_materials_manager_from_args_no_caching(
-        patch_parse_master_key_providers,
-        patch_aws_encryption_sdk
+    patch_parse_master_key_providers, patch_aws_encryption_sdk
 ):
     test = master_key_parsing.build_crypto_materials_manager_from_args(
-        key_providers_config=(sentinel.key_config_1, sentinel.key_config_2),
-        caching_config=None
+        key_providers_config=(sentinel.key_config_1, sentinel.key_config_2), caching_config=None
     )
 
     patch_parse_master_key_providers.assert_called_once_with(sentinel.key_config_1, sentinel.key_config_2)
@@ -287,19 +244,18 @@ def test_build_crypto_materials_manager_from_args_no_caching(
 
 
 def test_build_crypto_materials_manager_from_args_with_caching(
-        patch_parse_master_key_providers,
-        patch_aws_encryption_sdk
+    patch_parse_master_key_providers, patch_aws_encryption_sdk
 ):
     test = master_key_parsing.build_crypto_materials_manager_from_args(
         key_providers_config=(sentinel.key_config_1, sentinel.key_config_2),
-        caching_config={'a': 'cache_config_a', 'b': 'cache_config_b', 'capacity': 5}
+        caching_config={"a": "cache_config_a", "b": "cache_config_b", "capacity": 5},
     )
 
     patch_aws_encryption_sdk.LocalCryptoMaterialsCache.assert_called_once_with(capacity=5)
     patch_aws_encryption_sdk.CachingCryptoMaterialsManager.assert_called_once_with(
         backing_materials_manager=patch_aws_encryption_sdk.DefaultCryptoMaterialsManager.return_value,
         cache=patch_aws_encryption_sdk.LocalCryptoMaterialsCache.return_value,
-        a='cache_config_a',
-        b='cache_config_b'
+        a="cache_config_a",
+        b="cache_config_b",
     )
     assert test is patch_aws_encryption_sdk.CachingCryptoMaterialsManager.return_value

--- a/test/unit/test_metadata.py
+++ b/test/unit/test_metadata.py
@@ -23,23 +23,22 @@ from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal import metadata
 
 pytestmark = [pytest.mark.unit, pytest.mark.local]
-GOOD_INIT_KWARGS = dict(
-    suppress_output=False
+GOOD_INIT_KWARGS = dict(suppress_output=False)
+
+
+@pytest.mark.parametrize(
+    "init_kwargs, call_kwargs",
+    (
+        (dict(suppress_output=True), dict()),
+        (dict(suppress_output=False), dict(output_file="-")),
+        (dict(suppress_output=False), dict(output_file="asdf")),
+    ),
 )
-
-
-@pytest.mark.parametrize('init_kwargs, call_kwargs', (
-    (dict(suppress_output=True), dict()),
-    (dict(suppress_output=False), dict(output_file='-')),
-    (dict(suppress_output=False), dict(output_file='asdf'))
-))
 def test_attrs_good(init_kwargs, call_kwargs):
     metadata.MetadataWriter(**init_kwargs)(**call_kwargs)
 
 
-@pytest.mark.parametrize('init_kwargs_patch, error_type', (
-    (dict(suppress_output=None), TypeError),
-))
+@pytest.mark.parametrize("init_kwargs_patch, error_type", ((dict(suppress_output=None), TypeError),))
 def test_attrs_fail(init_kwargs_patch, error_type):
     """Verifying that validators are applied because we overwrite attrs init."""
     init_kwargs = GOOD_INIT_KWARGS.copy()
@@ -49,14 +48,10 @@ def test_attrs_fail(init_kwargs_patch, error_type):
         metadata.MetadataWriter(**init_kwargs)()
 
 
-@pytest.mark.parametrize('init_kwargs, call_kwargs, error_type, error_message', (
-    (
-        dict(suppress_output=False),
-        dict(),
-        TypeError,
-        r'output_file cannot be None when suppress_output is False'
-    ),
-))
+@pytest.mark.parametrize(
+    "init_kwargs, call_kwargs, error_type, error_message",
+    ((dict(suppress_output=False), dict(), TypeError, r"output_file cannot be None when suppress_output is False"),),
+)
 def test_custom_fail(init_kwargs, call_kwargs, error_type, error_message):
     with pytest.raises(error_type) as excinfo:
         metadata.MetadataWriter(**init_kwargs)(**call_kwargs)
@@ -64,12 +59,10 @@ def test_custom_fail(init_kwargs, call_kwargs, error_type, error_message):
     excinfo.match(error_message)
 
 
-@pytest.mark.parametrize('filename, force_overwrite, expected_mode', (
-    ('a_file', False, 'ab'),
-    ('-', False, 'w'),
-    ('a_file', True, 'wb'),
-    ('-', True, 'wb')
-))
+@pytest.mark.parametrize(
+    "filename, force_overwrite, expected_mode",
+    (("a_file", False, "ab"), ("-", False, "w"), ("a_file", True, "wb"), ("-", True, "wb")),
+)
 def test_write_metadata_default_output_modes(filename, force_overwrite, expected_mode):
     test = metadata.MetadataWriter(suppress_output=False)(filename)
     if force_overwrite:
@@ -78,32 +71,26 @@ def test_write_metadata_default_output_modes(filename, force_overwrite, expected
     assert test._output_mode == expected_mode
 
 
-@pytest.mark.parametrize('suppress', (True, False))
+@pytest.mark.parametrize("suppress", (True, False))
 def test_write_or_suppress_metadata_stdout(capsys, suppress):
-    my_metadata = {
-        'some': 'data',
-        'for': 'this metadata'
-    }
+    my_metadata = {"some": "data", "for": "this metadata"}
     writer_factory = metadata.MetadataWriter(suppress_output=suppress)
-    writer = writer_factory('-')
+    writer = writer_factory("-")
 
     with writer:
         writer.write_metadata(**my_metadata)
 
     out, _err = capsys.readouterr()
     if suppress:
-        assert out == ''
+        assert out == ""
     else:
         assert json.loads(out) == my_metadata
 
 
-@pytest.mark.parametrize('suppress', (True, False))
+@pytest.mark.parametrize("suppress", (True, False))
 def test_write_or_suppress_metadata_file(tmpdir, suppress):
-    my_metadata = {
-        'some': 'data',
-        'for': 'this metadata'
-    }
-    output_file = tmpdir.join('metadata')
+    my_metadata = {"some": "data", "for": "this metadata"}
+    output_file = tmpdir.join("metadata")
     writer_factory = metadata.MetadataWriter(suppress_output=suppress)
     writer = writer_factory(str(output_file))
 
@@ -117,11 +104,8 @@ def test_write_or_suppress_metadata_file(tmpdir, suppress):
 
 
 def test_write_or_suppress_metadata_file_open_close(tmpdir):
-    my_metadata = {
-        'some': 'data',
-        'for': 'this metadata'
-    }
-    output_file = tmpdir.join('metadata')
+    my_metadata = {"some": "data", "for": "this metadata"}
+    output_file = tmpdir.join("metadata")
     writer_factory = metadata.MetadataWriter(suppress_output=False)
     writer = writer_factory(str(output_file))
 
@@ -135,13 +119,10 @@ def test_write_or_suppress_metadata_file_open_close(tmpdir):
 
 
 def test_append_metadata_file(tmpdir):
-    initial_data = 'some data'
-    my_metadata = {
-        'some': 'data',
-        'for': 'this metadata'
-    }
-    output_file = tmpdir.join('metadata')
-    output_file.write_binary((initial_data + os.linesep).encode('utf-8'))
+    initial_data = "some data"
+    my_metadata = {"some": "data", "for": "this metadata"}
+    output_file = tmpdir.join("metadata")
+    output_file.write_binary((initial_data + os.linesep).encode("utf-8"))
 
     with metadata.MetadataWriter(suppress_output=False)(str(output_file)) as writer:
         writer.write_metadata(**my_metadata)
@@ -153,12 +134,9 @@ def test_append_metadata_file(tmpdir):
 
 
 def test_overwrite_metdata_file(tmpdir):
-    initial_data = 'some data'
-    my_metadata = {
-        'some': 'data',
-        'for': 'this metadata'
-    }
-    output_file = tmpdir.join('metadata')
+    initial_data = "some data"
+    my_metadata = {"some": "data", "for": "this metadata"}
+    output_file = tmpdir.join("metadata")
     output_file.write(initial_data + os.linesep)
 
     overwrite_writer = metadata.MetadataWriter(suppress_output=False)(str(output_file))
@@ -173,23 +151,20 @@ def test_overwrite_metdata_file(tmpdir):
 
 
 def test_overwrite_metdata_file_multiuse(tmpdir):
-    initial_data = 'some data'
-    my_metadata = {
-        'some': 'data',
-        'for': 'this metadata'
-    }
-    output_file = tmpdir.join('metadata')
+    initial_data = "some data"
+    my_metadata = {"some": "data", "for": "this metadata"}
+    output_file = tmpdir.join("metadata")
     output_file.write(initial_data + os.linesep)
 
     long_lived_writer = metadata.MetadataWriter(suppress_output=False)(str(output_file))
     long_lived_writer.force_overwrite()
 
-    assert long_lived_writer._output_mode == 'wb'
+    assert long_lived_writer._output_mode == "wb"
 
     with long_lived_writer as writer:
         writer.write_metadata(**my_metadata)
 
-    assert long_lived_writer._output_mode == 'ab'
+    assert long_lived_writer._output_mode == "ab"
 
     with long_lived_writer as writer:
         writer.write_metadata(**my_metadata)
@@ -201,96 +176,95 @@ def test_overwrite_metdata_file_multiuse(tmpdir):
 
 
 def test_metadata_output_file_parent_dir_does_not_exist(tmpdir):
-    metadata_file = os.path.join(str(tmpdir), 'missing_dir', 'metadata')
+    metadata_file = os.path.join(str(tmpdir), "missing_dir", "metadata")
 
     with pytest.raises(BadUserArgumentError) as excinfo:
         metadata.MetadataWriter(suppress_output=False)(metadata_file)
 
-    excinfo.match(r'Parent directory for requested metdata file does not exist.')
+    excinfo.match(r"Parent directory for requested metdata file does not exist.")
 
 
 def test_json_ready_message_header():
     # pylint: disable=too-many-locals
-    message_id = b'a message ID'
-    encryption_context = {'a': 'b', 'c': 'd'}
+    message_id = b"a message ID"
+    encryption_context = {"a": "b", "c": "d"}
     content_aad_length = 8
     iv_length = 17
     frame_length = 99
-    master_key_provider_id_1 = b'provider 1'
-    master_key_provider_info_1 = b'master key 1'
-    encrypted_data_key_1 = b'an encrypted data key1'
-    master_key_provider_id_2 = b'provider 1'
-    master_key_provider_info_2 = b'master key 2'
-    encrypted_data_key_2 = b'an encrypted data key2'
-    master_key_provider_id_3 = b'another provider'
-    master_key_provider_info_3 = b'master key 3'
-    encrypted_data_key_3 = b'an encrypted data key3'
+    master_key_provider_id_1 = b"provider 1"
+    master_key_provider_info_1 = b"master key 1"
+    encrypted_data_key_1 = b"an encrypted data key1"
+    master_key_provider_id_2 = b"provider 1"
+    master_key_provider_info_2 = b"master key 2"
+    encrypted_data_key_2 = b"an encrypted data key2"
+    master_key_provider_id_3 = b"another provider"
+    master_key_provider_info_3 = b"master key 3"
+    encrypted_data_key_3 = b"an encrypted data key3"
     raw_header = MessageHeader(
         version=SerializationVersion.V1,
         type=ObjectType.CUSTOMER_AE_DATA,
         algorithm=Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
         message_id=message_id,
         encryption_context=encryption_context,
-        encrypted_data_keys=set([
-            EncryptedDataKey(
-                key_provider=MasterKeyInfo(
-                    provider_id=master_key_provider_id_1,
-                    key_info=master_key_provider_info_1
+        encrypted_data_keys=set(
+            [
+                EncryptedDataKey(
+                    key_provider=MasterKeyInfo(
+                        provider_id=master_key_provider_id_1, key_info=master_key_provider_info_1
+                    ),
+                    encrypted_data_key=encrypted_data_key_1,
                 ),
-                encrypted_data_key=encrypted_data_key_1
-            ),
-            EncryptedDataKey(
-                key_provider=MasterKeyInfo(
-                    provider_id=master_key_provider_id_2,
-                    key_info=master_key_provider_info_2
+                EncryptedDataKey(
+                    key_provider=MasterKeyInfo(
+                        provider_id=master_key_provider_id_2, key_info=master_key_provider_info_2
+                    ),
+                    encrypted_data_key=encrypted_data_key_2,
                 ),
-                encrypted_data_key=encrypted_data_key_2
-            ),
-            EncryptedDataKey(
-                key_provider=MasterKeyInfo(
-                    provider_id=master_key_provider_id_3,
-                    key_info=master_key_provider_info_3
+                EncryptedDataKey(
+                    key_provider=MasterKeyInfo(
+                        provider_id=master_key_provider_id_3, key_info=master_key_provider_info_3
+                    ),
+                    encrypted_data_key=encrypted_data_key_3,
                 ),
-                encrypted_data_key=encrypted_data_key_3
-            )
-        ]),
+            ]
+        ),
         content_type=ContentType.FRAMED_DATA,
         content_aad_length=content_aad_length,
         header_iv_length=iv_length,
-        frame_length=frame_length
+        frame_length=frame_length,
     )
     expected_header_dict = {
-        'version': '1.0',
-        'type': ObjectType.CUSTOMER_AE_DATA.value,
-        'algorithm': Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384.name,
-        'message_id': metadata.unicode_b64_encode(message_id),
-        'encryption_context': encryption_context,
-        'encrypted_data_keys': [
+        "version": "1.0",
+        "type": ObjectType.CUSTOMER_AE_DATA.value,
+        "algorithm": Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384.name,
+        "message_id": metadata.unicode_b64_encode(message_id),
+        "encryption_context": encryption_context,
+        "encrypted_data_keys": [
             {
-                'key_provider': {
-                    'provider_id': metadata.unicode_b64_encode(master_key_provider_id_3),
-                    'key_info': metadata.unicode_b64_encode(master_key_provider_info_3)
+                "key_provider": {
+                    "provider_id": metadata.unicode_b64_encode(master_key_provider_id_3),
+                    "key_info": metadata.unicode_b64_encode(master_key_provider_info_3),
                 },
-                'encrypted_data_key': metadata.unicode_b64_encode(encrypted_data_key_3)
+                "encrypted_data_key": metadata.unicode_b64_encode(encrypted_data_key_3),
             },
             {
-                'key_provider': {
-                    'provider_id': metadata.unicode_b64_encode(master_key_provider_id_1),
-                    'key_info': metadata.unicode_b64_encode(master_key_provider_info_1)
+                "key_provider": {
+                    "provider_id": metadata.unicode_b64_encode(master_key_provider_id_1),
+                    "key_info": metadata.unicode_b64_encode(master_key_provider_info_1),
                 },
-                'encrypted_data_key': metadata.unicode_b64_encode(encrypted_data_key_1)
+                "encrypted_data_key": metadata.unicode_b64_encode(encrypted_data_key_1),
             },
             {
-                'key_provider': {
-                    'provider_id': metadata.unicode_b64_encode(master_key_provider_id_2),
-                    'key_info': metadata.unicode_b64_encode(master_key_provider_info_2)
+                "key_provider": {
+                    "provider_id": metadata.unicode_b64_encode(master_key_provider_id_2),
+                    "key_info": metadata.unicode_b64_encode(master_key_provider_info_2),
                 },
-                'encrypted_data_key': metadata.unicode_b64_encode(encrypted_data_key_2)
-            }
+                "encrypted_data_key": metadata.unicode_b64_encode(encrypted_data_key_2),
+            },
         ],
-        'content_type': ContentType.FRAMED_DATA.value,
-        'header_iv_length': iv_length,
-        'frame_length': frame_length
+        "content_type": ContentType.FRAMED_DATA.value,
+        "header_iv_length": iv_length,
+        "frame_length": frame_length,
     }
 
     test = metadata.json_ready_header(raw_header)
@@ -301,13 +275,10 @@ def test_json_ready_message_header():
 
 
 def test_json_ready_header_auth():
-    iv = b'some random bytes'
-    tag = b'some not random bytes'
+    iv = b"some random bytes"
+    tag = b"some not random bytes"
     raw_header_auth = MessageHeaderAuthentication(iv=iv, tag=tag)
-    expected_header_auth_dict = {
-        'iv': metadata.unicode_b64_encode(iv),
-        'tag': metadata.unicode_b64_encode(tag)
-    }
+    expected_header_auth_dict = {"iv": metadata.unicode_b64_encode(iv), "tag": metadata.unicode_b64_encode(tag)}
 
     test = metadata.json_ready_header_auth(raw_header_auth)
 

--- a/test/unit/test_metadata.py
+++ b/test/unit/test_metadata.py
@@ -14,10 +14,10 @@
 import json
 import os
 
+import pytest
 from aws_encryption_sdk.identifiers import Algorithm, ContentType, ObjectType, SerializationVersion
 from aws_encryption_sdk.internal.structures import MessageHeaderAuthentication
 from aws_encryption_sdk.structures import EncryptedDataKey, MasterKeyInfo, MessageHeader
-import pytest
 
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal import metadata

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -13,7 +13,7 @@
 """Utility functions to handle configuration, credentials setup, and test skip decision making for unit tests."""
 import platform
 
-WINDOWS_SKIP_MESSAGE = 'Skipping test on Windows'
+WINDOWS_SKIP_MESSAGE = "Skipping test on Windows"
 
 
 def is_windows():

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     mypy-py{2,3},
     bandit, doc8, readme, docs,
     flake8, pylint,
-    flake8-tests, pylint-tests
+    flake8-tests, pylint-tests,
+    isort-check, black-check
 
 # Additional test environments:
 # vulture :: Runs vulture. Prone to false-positives.

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,6 @@ basepython = python3
 deps =
     flake8
     flake8-docstrings
-    flake8-import-order
     flake8-print>=3.0.1
 commands =
     flake8 \

--- a/tox.ini
+++ b/tox.ini
@@ -104,6 +104,56 @@ commands =
         --ignore F811,D103,D401 \
         test/
 
+[testenv:blacken-src]
+basepython = python3
+deps =
+    black
+commands =
+    black --line-length 120 \
+        src/aws_encryption_sdk_cli/ \
+        setup.py \
+        doc/conf.py \
+        test/
+
+[testenv:blacken-docs]
+basepython = python3
+deps =
+    blacken-docs
+commands =
+    blacken-docs --line-length 90 \
+        README.rst
+
+
+[testenv:blacken]
+basepython = python3
+deps =
+    {[testenv:blacken-src]deps}
+    {[testenv:blacken-docs]deps}
+commands =
+    {[testenv:blacken-src]commands}
+    {[testenv:blacken-docs]commands}
+
+[testenv:black-check]
+basepython = python3
+deps =
+    {[testenv:blacken]deps}
+commands =
+    {[testenv:blacken-src]commands} --diff
+
+[testenv:isort]
+basepython = python3
+deps = isort
+commands = isort -rc \
+    src \
+    test \
+    doc \
+    setup.py
+
+[testenv:isort-check]
+basepython = python3
+deps = {[testenv:isort]deps}
+commands = {[testenv:isort]commands} -c
+
 [testenv:pylint]
 basepython = python3
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -125,24 +125,13 @@ commands =
         test/ \
         {posargs}
 
-[testenv:blacken-docs]
-basepython = python3
-deps =
-    blacken-docs
-commands =
-    blacken-docs --line-length 90 \
-        README.rst \
-        {posargs}
-
 
 [testenv:blacken]
 basepython = python3
 deps =
     {[testenv:blacken-src]deps}
-    {[testenv:blacken-docs]deps}
 commands =
     {[testenv:blacken-src]commands}
-    {[testenv:blacken-docs]commands}
 
 [testenv:black-check]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -13,14 +13,13 @@ envlist =
 # linters-tests :: Runs all linters over all tests.
 
 # Autoformatter helper environments:
-# black-check : Check for black issues
-# blacken : Fix all black and black-docs issues
+# black-check : Check for "black" issues
+# blacken : Fix all "black" issues
 # isort-seed : Generate a known_third_party list for isort.
 #   NOTE: generates in .isort.cfg; move to isort section in setup.cfg
 #   NOTE: currently it incorrectly identifies this library too; make sure you remove it
 # isort-check : Check for isort issues
 # isort : Fix isort issues
-
 
 # Operational helper environments:
 # docs :: Builds Sphinx documentation.

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,16 @@ envlist =
 # linters :: Runs all linters over all source code.
 # linters-tests :: Runs all linters over all tests.
 
+# Autoformatter helper environments:
+# black-check : Check for black issues
+# blacken : Fix all black and black-docs issues
+# isort-seed : Generate a known_third_party list for isort.
+#   NOTE: generates in .isort.cfg; move to isort section in setup.cfg
+#   NOTE: currently it incorrectly identifies this library too; make sure you remove it
+# isort-check : Check for isort issues
+# isort : Fix isort issues
+
+
 # Operational helper environments:
 # docs :: Builds Sphinx documentation.
 # serve-docs :: Starts local webserver to serve built documentation.
@@ -112,7 +122,8 @@ commands =
         src/aws_encryption_sdk_cli/ \
         setup.py \
         doc/conf.py \
-        test/
+        test/ \
+        {posargs}
 
 [testenv:blacken-docs]
 basepython = python3
@@ -120,7 +131,8 @@ deps =
     blacken-docs
 commands =
     blacken-docs --line-length 90 \
-        README.rst
+        README.rst \
+        {posargs}
 
 
 [testenv:blacken]
@@ -139,6 +151,11 @@ deps =
 commands =
     {[testenv:blacken-src]commands} --diff
 
+[testenv:isort-seed]
+basepython = python3
+deps = seed-isort-config
+commands = seed-isort-config
+
 [testenv:isort]
 basepython = python3
 deps = isort
@@ -146,7 +163,8 @@ commands = isort -rc \
     src \
     test \
     doc \
-    setup.py
+    setup.py \
+    {posargs}
 
 [testenv:isort-check]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -111,7 +111,9 @@ commands =
         # Ignore F811 redefinition errors in tests (breaks with pytest-mock use)
         # Ignore D103 docstring requirements for tests
         # Ignore D401 imperative mood for module docstrings (was hanging up on integration_test_utils)
-        --ignore F811,D103,D401 \
+        # E203 is not PEP8 compliant https://github.com/ambv/black#slices
+        # W503 is not PEP8 compliant https://github.com/ambv/black#line-breaks--binary-operators
+        --ignore F811,D103,D401,E203,W503 \
         test/
 
 [testenv:blacken-src]


### PR DESCRIPTION
*Description of changes:*
My primary focus here was to clean up some issues identified by new checks in Pylint 2.0, but in order to prep for that I wanted to get the codebase set up with `black` and `isort`. This does that, and since there is so much here already (granted, 99% done by `black` and `isort`), I didn't want to blur the lines too much by incorporating the Pylint fixes.

Because of that, Travis will fail on both the `pylint` and `pylint-tests` stages, but the new `black-check` and `isort-check` stages will pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
