### PR TITLE
add CPython 3.7 to tox envlist and CI configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,29 +18,33 @@ matrix:
       env: TOXENV=py36-local
     - python: 3.6
       env: TOXENV=py36-integ
-    - python: 3.6
+    - python: 3.7
+      env: TOXENV=py37-local
+    - python: 3.7
+      env: TOXENV=py37-integ
+    - python: 3.7
       env: TOXENV=mypy-py2
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=mypy-py3
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=bandit
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=doc8
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=readme
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=docs
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=flake8
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=pylint
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=flake8-tests
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=pylint-tests
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=black-check
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=isort-check
 install: pip install tox
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,31 +20,35 @@ matrix:
       env: TOXENV=py36-integ
     - python: 3.7
       env: TOXENV=py37-local
+      dist: xenial
+      sudo: true
     - python: 3.7
       env: TOXENV=py37-integ
-    - python: 3.7
+      dist: xenial
+      sudo: true
+    - python: 3.6
       env: TOXENV=mypy-py2
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=mypy-py3
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=bandit
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=doc8
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=readme
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=docs
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=flake8
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=pylint
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=flake8-tests
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=pylint-tests
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=black-check
-    - python: 3.7
+    - python: 3.6
       env: TOXENV=isort-check
 install: pip install tox
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ aws-encryption-sdk-cli
    :target: https://pypi.python.org/pypi/aws-encryption-sdk-cli
    :alt: Latest Version
 
-.. image:: https://img.shields.io/pypi/pyversions/base64io.svg
-   :target: https://pypi.python.org/pypi/base64io
+.. image:: https://img.shields.io/pypi/pyversions/aws-encryption-sdk-cli.svg
+   :target: https://pypi.python.org/pypi/aws-encryption-sdk-cli
    :alt: Supported Python Versions
 
 .. image:: https://img.shields.io/badge/code_style-black-000000.svg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,16 @@ environment:
     - PYTHON: "C:\\Python36-x64"
       TOXENV: "py36-integ"
 
+    # Python 3.7
+    - PYTHON: "C:\\Python37"
+      TOXENV: "py37-local"
+    - PYTHON: "C:\\Python37"
+      TOXENV: "py37-integ"
+    - PYTHON: "C:\\Python37-x64"
+      TOXENV: "py37-local"
+    - PYTHON: "C:\\Python37-x64"
+      TOXENV: "py37-integ"
+
 install:
   # Prepend newly installed Python to the PATH of this build
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Security",
         "Topic :: Security :: Cryptography",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36}-{local,integ},
+    py{27,34,35,36,37}-{local,integ},
     mypy-py{2,3},
     bandit, doc8, readme, docs,
     flake8, pylint,


### PR DESCRIPTION
*Issue #, if available:* #151 

*Description of changes:*
CPython 3.0 was released last month. We should start testing it.

I also realized after merging #150 that I forgot to point the pyversions badge at the correct repo..so this fixes that too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
